### PR TITLE
remove now-stable feature opt-in - issue #30

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 #![crate_name = "riker"]
-#![feature(assoc_unix_epoch)]
 
 extern crate bytes;
 extern crate chrono;


### PR DESCRIPTION
As per the issue: a feature has stabilized and therefore there's no need to opt-in to it.