### PR TITLE
Make replay_event on Box<Actor> actually call replay_event

### DIFF
--- a/src/actor/actor.rs
+++ b/src/actor/actor.rs
@@ -248,7 +248,7 @@ impl<A: Actor + ?Sized> Actor for Box<A> {
     }
 
     fn replay_event(&mut self, ctx: &Context<Self::Msg>, evt: Self::Msg) {
-        (**self).apply_event(ctx, evt)
+        (**self).replay_event(ctx, evt)
     }
 
     fn supervisor_strategy(&self) -> Strategy {


### PR DESCRIPTION
The Actor implementation for Box<Actor> calls apply_event in its replay_event wrapper.