### PR TITLE
Removed duplicate ActorRefFactory impl

### DIFF
--- a/src/actor/channel.rs
+++ b/src/actor/channel.rs
@@ -416,7 +416,7 @@ impl From<SysTopic> for Topic {
     }
 }
 
-pub fn channel<Msg>(name: &str, fact: impl ActorRefFactory)
+pub fn channel<Msg>(name: &str, fact: &impl ActorRefFactory)
                     -> Result<ChannelRef<Msg>, CreateError>
     where Msg: Message
 {

--- a/src/system/system.rs
+++ b/src/system/system.rs
@@ -355,24 +355,6 @@ impl ActorRefFactory for ActorSystem {
     }
 }
 
-impl ActorRefFactory for &ActorSystem {
-    fn actor_of<A>(&self,
-                props: BoxActorProd<A>,
-                name: &str) -> Result<ActorRef<A::Msg>, CreateError>
-        where A: Actor
-    {
-        self.provider
-            .create_actor(props,
-                        name,
-                        &self.user_root(),
-                        self)
-    }
-
-    fn stop(&self, actor: impl ActorReference) {
-        actor.sys_tell(SystemCmd::Stop.into());
-    }
-}
-
 impl TmpActorRefFactory for ActorSystem {
     fn tmp_actor_of<A>(&self, props: BoxActorProd<A>)
                     -> Result<ActorRef<A::Msg>, CreateError>


### PR DESCRIPTION
ActorRefFactory is implemented twice. Once for ActorSystem and once for &ActorSystem. Because the implementations are exactly the same, i think the second one is not needed.