### PR TITLE
Switch to .await syntax. Reduce number of unstable feature flags.

### DIFF
--- a/src/kernel/kernel.rs
+++ b/src/kernel/kernel.rs
@@ -61,7 +61,7 @@ pub fn kernel<A>(props: BoxActorProd<A>,
     let actor_ref = ActorRef::new(cell);
 
     let f = async move {
-        while let Some(msg) = await!(rx.next()) {
+        while let Some(msg) = rx.next().await {
             match msg {
                 KernelMsg::RunActor => {
                     let ctx = Context {

--- a/src/kernel/kernel_ref.rs
+++ b/src/kernel/kernel_ref.rs
@@ -43,7 +43,7 @@ impl KernelRef {
         let mut exec = sys.exec.clone(); 
         exec.spawn(
             async move {
-                await!(tx.send(msg)).unwrap();
+                tx.send(msg).await.unwrap();
             }
         ).unwrap();
     } 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,5 @@
 #![crate_name = "riker"]
-#![feature(
-        async_await,
-        await_macro,
-        arbitrary_self_types,
-        bind_by_move_pattern_guards
-)]
+#![feature(async_await)]
 
 // #![allow(warnings)] // toggle for easier compile error fixing 
 
@@ -84,8 +79,13 @@ impl AnyMessage {
     {
         if self.one_time {
             match self.msg.take() {
-                Some(m) if m.is::<T>() => Ok(*m.downcast::<T>().unwrap()),
-                Some(_) => Err(()),
+                Some(m) => {
+                    if m.is::<T>() {
+                        Ok(*m.downcast::<T>().unwrap())
+                    } else {
+                        Err(())
+                    }
+                },
                 None => Err(())
             }
         } else {


### PR DESCRIPTION
This PR switches from await! macro to .await keyword which does not require a separate feature gate.
It also removes unnecessary dependency on unstable `bind_by_move_pattern_guards` feature.