### PR TITLE
Remove feature arbitrary_self_types

### DIFF
--- a/tests/system.rs
+++ b/tests/system.rs
@@ -1,4 +1,4 @@
-#![feature(async_await, await_macro, arbitrary_self_types)]
+#![feature(async_await, await_macro)]
 
 use futures::executor::block_on;
 use riker::actors::*;


### PR DESCRIPTION
Remove feature arbitrary_self_types from one of the tests because it isn't needed. (compiles & runs without it).