### PR TITLE
Allow for fully async actors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
-/target
+**/target
 **/*.rs.bk
+Cargo.lock
 .vscode
+.idea
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ bytes = "0.4"
 chrono = "0.4"
 config = "0.9"
 futures-preview = "0.3.0-alpha.18"
+futures-timer = "0.3.0"
 log = { version = "0.4", features = ["std"] }
 rand = "0.7"
 regex = "1.2"
@@ -29,4 +30,3 @@ pin-utils = "0.1.0-alpha.4"
 
 [dev-dependencies]
 riker-testkit = { git = "https://github.com/mrjoe7/riker-testkit.git" }
-futures-timer = "0.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riker"
-version = "0.3.2"
+version = "0.4.0"
 authors = ["Lee Smith <lee@riker.rs>"]
 edition = "2018"
 description = "Easily build fast, highly concurrent and resilient applications. An Actor Framework for Rust."
@@ -28,4 +28,5 @@ pin-utils = "0.1.0-alpha.4"
 
 
 [dev-dependencies]
-riker-testkit = "0.1.0"
+riker-testkit = { git = "https://github.com/mrjoe7/riker-testkit.git" }
+futures-timer = "0.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,9 @@ chrono = "0.4"
 config = "0.9"
 futures-preview = "0.3.0-alpha.18"
 log = { version = "0.4", features = ["std"] }
-rand = "0.4"
-regex = "0.2"
-uuid = { version = "0.6", features = ["v4"] }
+rand = "0.7"
+regex = "1.2"
+uuid = { version = "0.7", features = ["v4"] }
 pin-utils = "0.1.0-alpha.4"
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,11 @@ travis-ci = { repository = "riker-rs/riker" }
 
 [dependencies]
 riker-macros = { path = "riker-macros", version = "0.1" }
+async-trait = "0.1.11"
 bytes = "0.4"
 chrono = "0.4"
 config = "0.9"
-futures-preview = "0.3.0-alpha.16"
+futures-preview = "0.3.0-alpha.18"
 log = { version = "0.4", features = ["std"] }
 rand = "0.4"
 regex = "0.2"

--- a/README.md
+++ b/README.md
@@ -37,15 +37,17 @@ riker = "0.3.1"
 
 ```rust
 use std::time::Duration;
+use async_trait::async_trait;
 use riker::actors::*;
 
 struct MyActor;
 
 // implement the Actor trait
+#[async_trait]
 impl Actor for MyActor {
     type Msg = String;
 
-    fn recv(&mut self,
+    async fn recv(&mut self,
                 _ctx: &Context<String>,
                 msg: String,
                 _sender: Sender) {
@@ -66,15 +68,13 @@ impl MyActor {
 }
 
 // start the system and create an actor
-fn main() {
-    let sys = ActorSystem::new().unwrap();
+async fn app_foo() {
+    let sys = ActorSystem::new().await.unwrap();
 
     let props = MyActor::props();
-    let my_actor = sys.actor_of(props, "my-actor").unwrap();
+    let my_actor = sys.actor_of(props, "my-actor").await.unwrap();
 
-    my_actor.tell("Hello my actor!".to_string(), None);
-
-    std::thread::sleep(Duration::from_millis(500));
+    my_actor.tell("Hello my actor!".to_string(), None).await;
 }
 ```
 

--- a/riker-macros/Cargo.toml
+++ b/riker-macros/Cargo.toml
@@ -14,7 +14,8 @@ keywords = ["actors", "actor-model", "async", "cqrs", "event_sourcing"]
 proc-macro = true
 
 [dependencies]
-syn = { version ="0.15.39", features = ["parsing", "full", "extra-traits", "proc-macro"] }
-quote = "0.6.3"
-proc-macro2 = "0.4.4"
+syn = { version ="1.0.5", features = ["parsing", "full", "extra-traits", "proc-macro"] }
+quote = "1.0.2"
+proc-macro2 = "1.0.1"
+async-trait = "0.1.11"
 

--- a/riker-macros/src/lib.rs
+++ b/riker-macros/src/lib.rs
@@ -103,14 +103,15 @@ fn receive(aname: &Ident,
     let vars = types.types.iter().map(|t| {
         let vname = &t.name;
         quote!{
-            #name::#vname(msg) => <#aname>::receive(self, ctx, msg, sender),
+            #name::#vname(msg) => <#aname>::receive(self, ctx, msg, sender).await,
         }
     });
     quote!{
+        #[async_trait]
         impl Receive<#name> for #aname {
             type Msg = #name;
 
-            fn receive(&mut self,
+            async fn receive(&mut self,
                         ctx: &Context<Self::Msg>,
                         msg: #name,
                         sender: Option<BasicActorRef>) {

--- a/riker-macros/tests/macro.rs
+++ b/riker-macros/tests/macro.rs
@@ -83,7 +83,7 @@ trait Actor: Send + 'static {
     async fn post_start(&mut self, _ctx: &Context<Self::Msg>) {}
 
     /// Invoked after an actor has been stopped.
-    fn post_stop(&mut self) {}
+    async fn post_stop(&mut self) {}
 
     /// Invoked when an actor receives a message
     ///

--- a/src/actor/actor.rs
+++ b/src/actor/actor.rs
@@ -95,6 +95,7 @@ impl<A: Actor + ?Sized> Actor for Box<A> {
 /// ```
 /// use riker::actors::*;
 /// use async_trait::async_trait;
+/// use futures::executor::block_on;
 ///
 /// #[derive(Clone, Debug)]
 /// struct Foo;
@@ -150,11 +151,11 @@ impl<A: Actor + ?Sized> Actor for Box<A> {
 /// }
 ///
 /// // main
-/// let sys = ActorSystem::new().await.unwrap();
-/// let actor = sys.actor_of(MyActor::props(), "my-actor").await.unwrap();
+/// let sys = block_on(ActorSystem::new()).unwrap();
+/// let actor = block_on(sys.actor_of(MyActor::props(), "my-actor")).unwrap();
 ///
-/// actor.tell(Foo, None).await;
-/// actor.tell(Bar, None).await;
+/// block_on(actor.tell(Foo, None));
+/// block_on(actor.tell(Bar, None));
 /// ```
 #[async_trait]
 pub trait Receive<Msg: Message> {

--- a/src/actor/actor.rs
+++ b/src/actor/actor.rs
@@ -98,11 +98,11 @@ impl<A: Actor + ?Sized> Actor for Box<A> {
 /// use futures::executor::block_on;
 ///
 /// #[derive(Clone, Debug)]
-/// struct Foo;
+/// pub struct Foo;
 /// #[derive(Clone, Debug)]
-/// struct Bar;
+/// pub struct Bar;
 /// #[actor(Foo, Bar)] // <-- set our actor to receive Foo and Bar types
-/// struct MyActor;
+/// pub struct MyActor;
 ///
 /// #[async_trait]
 /// impl Actor for MyActor {

--- a/src/actor/actor.rs
+++ b/src/actor/actor.rs
@@ -150,11 +150,11 @@ impl<A: Actor + ?Sized> Actor for Box<A> {
 /// }
 ///
 /// // main
-/// let sys = ActorSystem::new().unwrap();
-/// let actor = sys.actor_of(MyActor::props(), "my-actor").unwrap();
+/// let sys = ActorSystem::new().await.unwrap();
+/// let actor = sys.actor_of(MyActor::props(), "my-actor").await.unwrap();
 ///
-/// actor.tell(Foo, None);
-/// actor.tell(Bar, None);
+/// actor.tell(Foo, None).await;
+/// actor.tell(Bar, None).await;
 /// ```
 #[async_trait]
 pub trait Receive<Msg: Message> {

--- a/src/actor/actor_cell.rs
+++ b/src/actor/actor_cell.rs
@@ -476,7 +476,7 @@ fn post_stop<A: Actor>(actor: &mut Option<A>) {
 /// Operations performed are in most cases done so from the
 /// actor's perspective. For example, creating a child actor
 /// using `ctx.actor_of` will create the child under the current
-/// actor within the heirarchy. In a similar manner, persistence
+/// actor within the hierarchy. In a similar manner, persistence
 /// operations such as `persist_event` use the current actor's
 /// persistence configuration.
 ///
@@ -515,8 +515,11 @@ impl<Msg: Message> ActorRefFactory for Context<Msg> {
             .create_actor(props, name, &parent, &self.system).await
     }
 
-    fn stop(&self, actor: impl ActorReference) {
-        actor.sys_tell(SystemCmd::Stop.into());
+    async fn stop<A>(&self, actor: A)
+        where
+            A: ActorReference
+    {
+        actor.sys_tell(SystemCmd::Stop.into()).await;
     }
 }
 

--- a/src/actor/actor_cell.rs
+++ b/src/actor/actor_cell.rs
@@ -199,7 +199,7 @@ impl ActorCell {
 
         if !self.has_children() {
             self.kernel().terminate().await;
-            post_stop(actor);
+            post_stop(actor).await;
         } else {
             for child in Box::new(self.inner.children.iter().clone()) {
                 self.stop(child.clone()).await;
@@ -226,7 +226,7 @@ impl ActorCell {
                 // No children exist. Stop this actor's kernel.
                 if self.inner.is_terminating.load(Ordering::Relaxed) {
                     self.kernel().terminate().await;
-                    post_stop(actor);
+                    post_stop(actor).await;
                 }
 
                 // No children exist. Restart the actor.
@@ -466,12 +466,12 @@ impl<Msg: Message> fmt::Debug for ExtendedCell<Msg> {
     }
 }
 
-fn post_stop<A: Actor>(actor: &mut Option<A>) {
+async fn post_stop<A: Actor>(actor: &mut Option<A>) {
     // If the actor instance exists we can execute post_stop.
     // The instance will be None if this is an actor that has failed
     // and is being terminated by an escalated supervisor.
     if let Some(act) = actor.as_mut() {
-        act.post_stop();
+        act.post_stop().await;
     }
 }
 

--- a/src/actor/actor_cell.rs
+++ b/src/actor/actor_cell.rs
@@ -558,11 +558,12 @@ where
     }
 }
 
+#[async_trait]
 impl<Msg> Timer for Context<Msg>
 where
     Msg: Message,
 {
-    fn schedule<T, M>(
+    async fn schedule<T, M>(
         &self,
         initial_delay: Duration,
         interval: Duration,
@@ -580,17 +581,17 @@ where
         let job = RepeatJob {
             id: id.clone(),
             send_at: SystemTime::now() + initial_delay,
-            interval: interval,
+            interval,
             receiver: receiver.into(),
-            sender: sender,
+            sender,
             msg: AnyMessage::new(msg, false),
         };
 
-        let _ = self.system.timer.send(Job::Repeat(job)).unwrap();
+        self.system.timer.send(Job::Repeat(job)).await.unwrap();
         id
     }
 
-    fn schedule_once<T, M>(
+    async fn schedule_once<T, M>(
         &self,
         delay: Duration,
         receiver: ActorRef<M>,
@@ -608,15 +609,15 @@ where
             id: id.clone(),
             send_at: SystemTime::now() + delay,
             receiver: receiver.into(),
-            sender: sender,
+            sender,
             msg: AnyMessage::new(msg, true),
         };
 
-        let _ = self.system.timer.send(Job::Once(job)).unwrap();
+        self.system.timer.send(Job::Once(job)).await.unwrap();
         id
     }
 
-    fn schedule_at_time<T, M>(
+    async fn schedule_at_time<T, M>(
         &self,
         time: DateTime<Utc>,
         receiver: ActorRef<M>,
@@ -636,16 +637,16 @@ where
             id: id.clone(),
             send_at: time,
             receiver: receiver.into(),
-            sender: sender,
+            sender,
             msg: AnyMessage::new(msg, true),
         };
 
-        let _ = self.system.timer.send(Job::Once(job)).unwrap();
+        self.system.timer.send(Job::Once(job)).await.unwrap();
         id
     }
 
-    fn cancel_schedule(&self, id: Uuid) {
-        let _ = self.system.timer.send(Job::Cancel(id));
+    async fn cancel_schedule(&self, id: Uuid) {
+        let _ = self.system.timer.send(Job::Cancel(id)).await.unwrap();
     }
 }
 

--- a/src/actor/actor_ref.rs
+++ b/src/actor/actor_ref.rs
@@ -177,8 +177,8 @@ impl BasicActorRef {
         ActorRef { cell }
     }
 
-    pub(crate) fn sys_init(&self, sys: &ActorSystem) {
-        self.cell.kernel().sys_init(sys);
+    pub(crate) async fn sys_init(&self, sys: &ActorSystem) {
+        self.cell.kernel().sys_init(sys).await;
     }
 
     /// Send a message to this actor

--- a/src/actor/channel.rs
+++ b/src/actor/channel.rs
@@ -60,7 +60,7 @@ where
         // };
 
         // let msg = ChannelMsg::Subscribe(sub);
-        // ctx.myself.tell(msg, None);
+        // ctx.myself.tell(msg, None).await;
     }
 
     async fn recv(&mut self, ctx: &ChannelCtx<Msg>, msg: ChannelMsg<Msg>, sender: Sender) {

--- a/src/actor/channel.rs
+++ b/src/actor/channel.rs
@@ -391,9 +391,9 @@ impl From<SysTopic> for Topic {
     }
 }
 
-pub fn channel<Msg>(name: &str, fact: &impl ActorRefFactory) -> Result<ChannelRef<Msg>, CreateError>
+pub async fn channel<Msg>(name: &str, fact: &impl ActorRefFactory) -> Result<ChannelRef<Msg>, CreateError>
 where
     Msg: Message,
 {
-    fact.actor_of(Channel::<Msg>::props(), name)
+    fact.actor_of(Channel::<Msg>::props(), name).await
 }

--- a/src/actor/props.rs
+++ b/src/actor/props.rs
@@ -23,6 +23,8 @@ impl Props {
     ///
     /// ```
     /// # use riker::actors::*;
+    /// # use async_trait::async_trait;
+    /// use futures::executor::block_on;
     ///
     /// struct User;
     ///
@@ -31,10 +33,10 @@ impl Props {
     ///         User
     ///     }
     /// }
-    ///
+    /// # #[async_trait]
     /// # impl Actor for User {
     /// #    type Msg = String;
-    /// #    fn recv(&mut self, _ctx: &Context<String>, _msg: String, _sender: Sender) {}
+    /// #    async fn recv(&mut self, _ctx: &Context<String>, _msg: String, _sender: Sender) {}
     /// # }
     /// // main
     /// let sys = ActorSystem::new().unwrap();
@@ -42,7 +44,7 @@ impl Props {
     /// let props = Props::new(User::actor);
     ///
     /// // start the actor and get an `ActorRef`
-    /// let actor = sys.actor_of(props, "user").unwrap();
+    /// let actor = block_on(sys.actor_of(props, "user")).unwrap();
     /// ```
     pub fn new<A, F>(creator: F) -> Arc<Mutex<impl ActorProducer<Actor = A>>>
     where
@@ -58,6 +60,8 @@ impl Props {
     /// An actor requiring a single parameter.
     /// ```
     /// # use riker::actors::*;
+    /// # use async_trait::async_trait;
+    /// use futures::executor::block_on;
     ///
     /// struct User {
     ///     name: String,
@@ -71,20 +75,23 @@ impl Props {
     ///     }
     /// }
     ///
+    /// # #[async_trait]
     /// # impl Actor for User {
     /// #    type Msg = String;
-    /// #    fn recv(&mut self, _ctx: &Context<String>, _msg: String, _sender: Sender) {}
+    /// #    async fn recv(&mut self, _ctx: &Context<String>, _msg: String, _sender: Sender) {}
     /// # }
     /// // main
     /// let sys = ActorSystem::new().unwrap();
     ///
     /// let props = Props::new_args(User::actor, "Naomi Nagata".into());
     ///
-    /// let actor = sys.actor_of(props, "user").unwrap();
+    /// let actor = block_on(sys.actor_of(props, "user")).unwrap();
     /// ```
     /// An actor requiring multiple parameters.
     /// ```
     /// # use riker::actors::*;
+    /// # use async_trait::async_trait;
+    /// use futures::executor::block_on;
     ///
     /// struct BankAccount {
     ///     name: String,
@@ -100,9 +107,10 @@ impl Props {
     ///     }
     /// }
     ///
+    /// # #[async_trait]
     /// # impl Actor for BankAccount {
     /// #    type Msg = String;
-    /// #    fn recv(&mut self, _ctx: &Context<String>, _msg: String, _sender: Sender) {}
+    /// #    async fn recv(&mut self, _ctx: &Context<String>, _msg: String, _sender: Sender) {}
     /// # }
     /// // main
     /// let sys = ActorSystem::new().unwrap();
@@ -111,7 +119,7 @@ impl Props {
     ///                             ("James Holden".into(), "12345678".into()));
     ///
     /// // start the actor and get an `ActorRef`
-    /// let actor = sys.actor_of(props, "bank_account").unwrap();
+    /// let actor = block_on(sys.actor_of(props, "bank_account")).unwrap();
     /// ```
     pub fn new_args<A, Args, F>(creator: F, args: Args) -> Arc<Mutex<impl ActorProducer<Actor = A>>>
     where

--- a/src/actor/props.rs
+++ b/src/actor/props.rs
@@ -39,7 +39,7 @@ impl Props {
     /// #    async fn recv(&mut self, _ctx: &Context<String>, _msg: String, _sender: Sender) {}
     /// # }
     /// // main
-    /// let sys = ActorSystem::new().unwrap();
+    /// let sys = block_on(ActorSystem::new()).unwrap();
     ///
     /// let props = Props::new(User::actor);
     ///
@@ -81,7 +81,7 @@ impl Props {
     /// #    async fn recv(&mut self, _ctx: &Context<String>, _msg: String, _sender: Sender) {}
     /// # }
     /// // main
-    /// let sys = ActorSystem::new().unwrap();
+    /// let sys = block_on(ActorSystem::new()).unwrap();
     ///
     /// let props = Props::new_args(User::actor, "Naomi Nagata".into());
     ///
@@ -113,7 +113,7 @@ impl Props {
     /// #    async fn recv(&mut self, _ctx: &Context<String>, _msg: String, _sender: Sender) {}
     /// # }
     /// // main
-    /// let sys = ActorSystem::new().unwrap();
+    /// let sys = block_on(ActorSystem::new()).unwrap();
     ///
     /// let props = Props::new_args(BankAccount::actor,
     ///                             ("James Holden".into(), "12345678".into()));

--- a/src/actor/selection.rs
+++ b/src/actor/selection.rs
@@ -138,6 +138,7 @@ impl ActorSelection {
         );
 
         // resolve all futures
+        to_tell.reverse();
         while let Some(fut) = to_tell.pop() {
             fut.await.unwrap();
         }
@@ -206,6 +207,7 @@ impl ActorSelection {
         );
 
         // resolve all futures
+        to_tell.reverse();
         while let Some(fut) = to_tell.pop() {
             fut.await;
         }

--- a/src/kernel/kernel.rs
+++ b/src/kernel/kernel.rs
@@ -86,7 +86,9 @@ where
         }
     };
 
+    // spawn processing
     sys.exec.spawn(f).unwrap();
+
     Ok(kr)
 }
 

--- a/src/kernel/kernel.rs
+++ b/src/kernel/kernel.rs
@@ -115,7 +115,7 @@ async fn terminate_actor<Msg>(mbox: &Mailbox<Msg>, actor_ref: BasicActorRef, sys
 where
     Msg: Message,
 {
-    sys.provider.unregister(actor_ref.path());
+    sys.provider.unregister(actor_ref.path()).await;
     flush_to_deadletters(mbox, &actor_ref, sys).await;
     sys.publish_event(
         ActorTerminated {

--- a/src/kernel/kernel.rs
+++ b/src/kernel/kernel.rs
@@ -102,8 +102,8 @@ async fn restart_actor<A>(
     match start_actor(props) {
         Ok(actor) => {
             *a = Some(actor);
-            actor_ref.sys_tell(SystemMsg::ActorInit);
-            sys.publish_event(ActorRestarted { actor: actor_ref }.into());
+            actor_ref.sys_tell(SystemMsg::ActorInit).await;
+            sys.publish_event(ActorRestarted { actor: actor_ref }.into()).await;
         }
         Err(_) => {
             warn!("Actor failed to restart: {:?}", actor_ref);
@@ -122,11 +122,11 @@ where
             actor: actor_ref.clone(),
         }
         .into(),
-    );
+    ).await;
 
     let parent = actor_ref.parent();
     if !parent.is_root() {
-        parent.sys_tell(ActorTerminated { actor: actor_ref }.into());
+        parent.sys_tell(ActorTerminated { actor: actor_ref }.into()).await;
     }
 }
 

--- a/src/kernel/kernel_ref.rs
+++ b/src/kernel/kernel_ref.rs
@@ -44,7 +44,7 @@ impl KernelRef {
     }
 }
 
-pub fn dispatch<Msg>(
+pub async fn dispatch<Msg>(
     msg: Envelope<Msg>,
     mbox: &MailboxSender<Msg>,
     kernel: &KernelRef,
@@ -53,7 +53,7 @@ pub fn dispatch<Msg>(
 where
     Msg: Message,
 {
-    match mbox.try_enqueue(msg) {
+    match mbox.try_enqueue(msg).await {
         Ok(_) => {
             if !mbox.is_scheduled() {
                 mbox.set_scheduled(true);
@@ -66,14 +66,14 @@ where
     }
 }
 
-pub fn dispatch_any(
+pub async fn dispatch_any(
     msg: &mut AnyMessage,
     sender: crate::actor::Sender,
     mbox: &Arc<dyn AnySender>,
     kernel: &KernelRef,
     sys: &ActorSystem,
 ) -> Result<(), ()> {
-    match mbox.try_any_enqueue(msg, sender) {
+    match mbox.try_any_enqueue(msg, sender).await {
         Ok(_) => {
             if !mbox.is_sched() {
                 mbox.set_sched(true);

--- a/src/kernel/kernel_ref.rs
+++ b/src/kernel/kernel_ref.rs
@@ -48,7 +48,7 @@ pub async fn dispatch<Msg>(
 where
     Msg: Message,
 {
-    match mbox.try_enqueue(msg).await {
+    match mbox.try_enqueue(msg) {
         Ok(_) => {
             if !mbox.is_scheduled() {
                 mbox.set_scheduled(true);
@@ -67,7 +67,7 @@ pub async fn dispatch_any(
     mbox: &Arc<dyn AnySender>,
     kernel: &KernelRef,
 ) -> Result<(), ()> {
-    match mbox.try_any_enqueue(msg, sender).await {
+    match mbox.try_any_enqueue(msg, sender) {
         Ok(_) => {
             if !mbox.is_sched() {
                 mbox.set_sched(true);

--- a/src/kernel/kernel_ref.rs
+++ b/src/kernel/kernel_ref.rs
@@ -80,5 +80,3 @@ pub async fn dispatch_any(
     }
 }
 
-unsafe impl Send for KernelRef {}
-unsafe impl Sync for KernelRef {}

--- a/src/kernel/mailbox.rs
+++ b/src/kernel/mailbox.rs
@@ -3,7 +3,6 @@ use std::sync::{
     Arc,
 };
 use std::thread;
-use async_trait::async_trait;
 
 use config::Config;
 use log::trace;

--- a/src/kernel/mailbox.rs
+++ b/src/kernel/mailbox.rs
@@ -304,7 +304,7 @@ async fn handle_init<A>(
 
     // if persistence is not configured then set as not suspended
     // if cell.load_events(actor) {
-    //     actor.as_mut().unwrap().post_start(ctx);
+    //     actor.as_mut().unwrap().post_start(ctx).await;
     //     mbox.set_suspended(false);
     // }
 }

--- a/src/kernel/provider.rs
+++ b/src/kernel/provider.rs
@@ -34,7 +34,7 @@ impl Provider {
         }
     }
 
-    pub fn create_actor<A>(
+    pub async fn create_actor<A>(
         &self,
         props: BoxActorProd<A>,
         name: &str,
@@ -71,7 +71,7 @@ impl Provider {
             sender.clone(),
         );
 
-        let k = kernel(props, cell.clone(), mb, sys)?;
+        let k = kernel(props, cell.clone(), mb, sys).await?;
         let cell = cell.init(&k);
 
         let actor = ActorRef::new(cell);
@@ -105,18 +105,18 @@ impl Provider {
     }
 }
 
-pub fn create_root(sys: &ActorSystem) -> SysActors {
-    let root = root(sys);
+pub async fn create_root(sys: &ActorSystem) -> SysActors {
+    let root = root(sys).await;
 
     SysActors {
         root: root.clone(),
-        user: guardian(1, "user", "/user", &root, sys),
-        sysm: guardian(2, "system", "/system", &root, sys),
-        temp: guardian(3, "temp", "/temp", &root, sys),
+        user: guardian(1, "user", "/user", &root, sys).await,
+        sysm: guardian(2, "system", "/system", &root, sys).await,
+        temp: guardian(3, "temp", "/temp", &root, sys).await,
     }
 }
 
-fn root(sys: &ActorSystem) -> BasicActorRef {
+async fn root(sys: &ActorSystem) -> BasicActorRef {
     let uri = ActorUri {
         uid: 0,
         name: Arc::new("root".to_string()),
@@ -162,14 +162,14 @@ fn root(sys: &ActorSystem) -> BasicActorRef {
         sender.clone(),
     );
 
-    let k = kernel(props, cell.clone(), mb, sys).unwrap();
+    let k = kernel(props, cell.clone(), mb, sys).await.unwrap();
     let cell = cell.init(&k);
     let actor_ref = ActorRef::new(cell);
 
     BasicActorRef::from(actor_ref)
 }
 
-fn guardian(
+async fn guardian(
     uid: ActorId,
     name: &str,
     path: &str,
@@ -197,7 +197,7 @@ fn guardian(
         sender.clone(),
     );
 
-    let k = kernel(props, cell.clone(), mb, sys).unwrap();
+    let k = kernel(props, cell.clone(), mb, sys).await.unwrap();
     let cell = cell.init(&k);
     let actor_ref = ActorRef::new(cell);
 

--- a/src/kernel/provider.rs
+++ b/src/kernel/provider.rs
@@ -3,6 +3,7 @@ use std::{
     collections::HashSet,
     sync::{Arc, Mutex},
 };
+use async_trait::async_trait;
 
 use crate::{
     actor::actor_cell::{ActorCell, ExtendedCell},
@@ -77,7 +78,7 @@ impl Provider {
         let actor = ActorRef::new(cell);
         let child = BasicActorRef::from(actor.clone());
         parent.cell.add_child(child);
-        actor.sys_tell(SystemMsg::ActorInit);
+        actor.sys_tell(SystemMsg::ActorInit).await;
 
         Ok(actor)
     }
@@ -218,12 +219,13 @@ impl Guardian {
     }
 }
 
+#[async_trait]
 impl Actor for Guardian {
     type Msg = SystemMsg;
 
-    fn recv(&mut self, _: &Context<Self::Msg>, _: Self::Msg, _: Option<BasicActorRef>) {}
+    async fn recv(&mut self, _: &Context<Self::Msg>, _: Self::Msg, _: Option<BasicActorRef>) {}
 
-    fn post_stop(&mut self) {
+    async fn post_stop(&mut self) {
         trace!("{} guardian stopped", self.name);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,6 @@
 
 // #![allow(warnings)] // toggle for easier compile error fixing
 
-#[allow(unused_imports)]
 extern crate log;
 
 mod validate;

--- a/src/system/logger.rs
+++ b/src/system/logger.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use config::Config;
 use log;
 use log::{info, Level};
@@ -72,10 +73,11 @@ impl SimpleLogger {
     }
 }
 
+#[async_trait]
 impl Actor for SimpleLogger {
     type Msg = LogEntry;
 
-    fn recv(&mut self, _: &Context<LogEntry>, entry: LogEntry, _: Option<BasicActorRef>) {
+    async fn recv(&mut self, _: &Context<LogEntry>, entry: LogEntry, _: Option<BasicActorRef>) {
         let now = chrono::Utc::now();
         let f_match: Vec<&String> = self
             .cfg
@@ -148,10 +150,11 @@ impl DeadLetterLogger {
     }
 }
 
+#[async_trait]
 impl Actor for DeadLetterLogger {
     type Msg = DeadLetter;
 
-    fn pre_start(&mut self, ctx: &Context<Self::Msg>) {
+    async fn pre_start(&mut self, ctx: &Context<Self::Msg>) {
         let sub = Box::new(ctx.myself());
         self.dl_chan.tell(
             Subscribe {
@@ -162,7 +165,7 @@ impl Actor for DeadLetterLogger {
         );
     }
 
-    fn recv(&mut self, _: &Context<Self::Msg>, msg: Self::Msg, _: Option<BasicActorRef>) {
+    async fn recv(&mut self, _: &Context<Self::Msg>, msg: Self::Msg, _: Option<BasicActorRef>) {
         info!(
             "DeadLetter: {:?} => {:?} ({:?})",
             msg.sender, msg.recipient, msg.msg

--- a/src/system/logger.rs
+++ b/src/system/logger.rs
@@ -37,7 +37,7 @@ impl log::Log for Logger {
         let actor = self.actor.clone();
         let log_entry = LogEntry::from(record);
         executor.spawn_ok(async move {
-            actor.tell(log_entry, None);
+            actor.tell(log_entry, None).await;
         });
     }
 

--- a/src/system/logger.rs
+++ b/src/system/logger.rs
@@ -33,7 +33,7 @@ impl log::Log for Logger {
     }
 
     fn log(&self, record: &log::Record) {
-        self.actor.tell(LogEntry::from(record), None);
+        self.actor.tell(LogEntry::from(record), None); // TODO: handle async
     }
 
     fn flush(&self) {}
@@ -162,7 +162,7 @@ impl Actor for DeadLetterLogger {
                 actor: sub,
             },
             None,
-        );
+        ).await;
     }
 
     async fn recv(&mut self, _: &Context<Self::Msg>, msg: Self::Msg, _: Option<BasicActorRef>) {

--- a/src/system/logger.rs
+++ b/src/system/logger.rs
@@ -33,7 +33,12 @@ impl log::Log for Logger {
     }
 
     fn log(&self, record: &log::Record) {
-        self.actor.tell(LogEntry::from(record), None); // TODO: handle async
+        let executor = &self.actor.cell.system().exec;
+        let actor = self.actor.clone();
+        let log_entry = LogEntry::from(record);
+        executor.spawn_ok(async move {
+            actor.tell(log_entry, None);
+        });
     }
 
     fn flush(&self) {}

--- a/src/system/persist.rs
+++ b/src/system/persist.rs
@@ -149,7 +149,7 @@ impl<Msg: Message> Actor for EsQueryActor<Msg> {
 
 // type QueryFuture<Msg> = Pin<Box<dyn Future<Output=Result<Vec<Msg>, Canceled>> + Send>>;
 
-pub fn query<Msg, Ctx>(id: &String,
+pub async fn query<Msg, Ctx>(id: &String,
                         keyspace: &String,
                         es: &ActorRef<Msg>,
                         ctx: &Ctx,
@@ -157,6 +157,6 @@ pub fn query<Msg, Ctx>(id: &String,
     where Msg: Message, Ctx: TmpActorRefFactory<Msg=Msg>
 {
     let props = Props::new_args(EsQueryActor::actor, rec);
-    let actor = ctx.tmp_actor_of(props).unwrap();
-    es.tell(ESMsg::Load(id.clone(), keyspace.clone()), Some(actor));
+    let actor = ctx.tmp_actor_of(props).await.unwrap();
+    es.tell(ESMsg::Load(id.clone(), keyspace.clone()), Some(actor)).await;
 }

--- a/src/system/timer.rs
+++ b/src/system/timer.rs
@@ -10,16 +10,14 @@ use crate::{
     AnyMessage, Message,
 };
 use futures::executor::ThreadPool;
-use std::sync::Arc;
-use futures::lock::Mutex;
 
 
 #[derive(Clone)]
-pub struct TimerRef(Arc<Mutex<UnboundedSender<Job>>>);
+pub struct TimerRef(UnboundedSender<Job>);
 
 impl TimerRef {
     pub async fn send(&self, job: Job) ->  Result<(), SendError> {
-        let tx = &mut self.0.lock().await;
+        let mut tx = self.0.clone();
         tx.send(job).await
     }
 }
@@ -135,7 +133,7 @@ impl BasicTimer {
             }
         });
 
-        TimerRef(Arc::new(Mutex::new(tx)))
+        TimerRef(tx)
     }
 
     pub async fn execute_once_jobs(&mut self) {

--- a/src/system/timer.rs
+++ b/src/system/timer.rs
@@ -121,7 +121,7 @@ impl BasicTimer {
                 process.execute_once_jobs().await;
                 process.execute_repeat_jobs().await;
 
-                while let Some(job) = rx.next().await {
+                while let Ok(Some(job)) = rx.try_next() {
                     match job {
                         Job::Cancel(id) => process.cancel(&id),
                         Job::Once(job) => process.schedule_once(job).await,

--- a/tests/actors.rs
+++ b/tests/actors.rs
@@ -1,13 +1,12 @@
 #[macro_use]
 extern crate riker_testkit;
 
-use async_trait::async_trait;
 use futures::executor::block_on;
-
-use riker::actors::*;
-
-use riker_testkit::probe::channel::{probe, ChannelProbe};
 use riker_testkit::probe::{Probe, ProbeReceive};
+use riker_testkit::probe::channel::{ChannelProbe, probe};
+
+use async_trait::async_trait;
+use riker::actors::*;
 
 #[derive(Clone, Debug)]
 pub struct Add;
@@ -56,6 +55,7 @@ impl Receive<Add> for Counter {
     async fn receive(&mut self, _ctx: &Context<Self::Msg>, _msg: Add, _sender: Sender) {
         self.count += 1;
         if self.count == 1_000_000 {
+            println!("1_000_000 reached!");
             self.probe.as_mut().unwrap().0.event(()).await;
         }
     }
@@ -187,6 +187,7 @@ fn actor_stop() {
 
         let (probe, mut listen) = probe();
         parent.tell(TestProbe(probe), None).await;
+
         system.print_tree();
 
         // wait for the probe to arrive at the actor before attempting to stop the actor

--- a/tests/actors.rs
+++ b/tests/actors.rs
@@ -62,15 +62,15 @@ fn actor_create() {
     let sys = block_on(ActorSystem::new()).unwrap();
 
     let props = Props::new(Counter::actor);
-    assert!(sys.actor_of(props.clone(), "valid-name").is_ok());
+    assert!(block_on(sys.actor_of(props.clone(), "valid-name")).is_ok());
 
-    assert!(sys.actor_of(props.clone(), "/").is_err());
-    assert!(sys.actor_of(props.clone(), "*").is_err());
-    assert!(sys.actor_of(props.clone(), "/a/b/c").is_err());
-    assert!(sys.actor_of(props.clone(), "@").is_err());
-    assert!(sys.actor_of(props.clone(), "#").is_err());
-    assert!(sys.actor_of(props.clone(), "abc*").is_err());
-    assert!(sys.actor_of(props, "!").is_err());
+    assert!(block_on(sys.actor_of(props.clone(), "/")).is_err());
+    assert!(block_on(sys.actor_of(props.clone(), "*")).is_err());
+    assert!(block_on(sys.actor_of(props.clone(), "/a/b/c")).is_err());
+    assert!(block_on(sys.actor_of(props.clone(), "@")).is_err());
+    assert!(block_on(sys.actor_of(props.clone(), "#")).is_err());
+    assert!(block_on(sys.actor_of(props.clone(), "abc*")).is_err());
+    assert!(block_on(sys.actor_of(props, "!")).is_err());
 }
 
 #[test]
@@ -78,7 +78,7 @@ fn actor_tell() {
     let sys = block_on(ActorSystem::new()).unwrap();
 
     let props = Props::new(Counter::actor);
-    let actor = sys.actor_of(props, "me").unwrap();
+    let actor = block_on(sys.actor_of(props, "me")).unwrap();
 
     let (probe, listen) = probe();
     actor.tell(TestProbe(probe), None);
@@ -167,7 +167,7 @@ impl Actor for Child {
 #[test]
 #[allow(dead_code)]
 fn actor_stop() {
-    let system = ActorSystem::new().unwrap();
+    let system = block_on(ActorSystem::new()).unwrap();
 
     let props = Props::new(Parent::actor);
     let parent = system.actor_of(props, "parent").unwrap();

--- a/tests/scheduling.rs
+++ b/tests/scheduling.rs
@@ -46,7 +46,7 @@ impl Receive<TestProbe> for ScheduleOnce {
     async fn receive(&mut self, ctx: &Context<ScheduleOnceMsg>, msg: TestProbe, _sender: Sender) {
         self.probe = Some(msg);
         // reschedule an Empty to be sent to myself()
-        ctx.schedule_once(Duration::from_millis(200), ctx.myself(), None, SomeMessage);
+        ctx.schedule_once(Duration::from_millis(200), ctx.myself(), None, SomeMessage).await;
     }
 }
 
@@ -70,7 +70,7 @@ fn schedule_once() {
         let (probe, mut listen) = probe();
 
         // use scheduler to set up probe
-        sys.schedule_once(Duration::from_millis(200), actor, None, TestProbe(probe));
+        sys.schedule_once(Duration::from_millis(200), actor, None, TestProbe(probe)).await;
         p_assert_eq!(listen, ());
     });
 }
@@ -87,7 +87,7 @@ fn schedule_at_time() {
 
         // use scheduler to set up probe at a specific time
         let schedule_at = Utc::now() + CDuration::milliseconds(200);
-        sys.schedule_at_time(schedule_at, actor, None, TestProbe(probe));
+        sys.schedule_at_time(schedule_at, actor, None, TestProbe(probe)).await;
         p_assert_eq!(listen, ());
     });
 }
@@ -133,7 +133,7 @@ impl Receive<TestProbe> for ScheduleRepeat {
             ctx.myself(),
             None,
             SomeMessage,
-        );
+        ).await;
         self.schedule_id = Some(id);
     }
 }
@@ -144,7 +144,7 @@ impl Receive<SomeMessage> for ScheduleRepeat {
 
     async fn receive(&mut self, ctx: &Context<Self::Msg>, _msg: SomeMessage, _sender: Sender) {
         if self.counter == 5 {
-            ctx.cancel_schedule(self.schedule_id.unwrap());
+            ctx.cancel_schedule(self.schedule_id.unwrap()).await;
             self.probe.as_mut().unwrap().0.event(()).await;
         } else {
             self.counter += 1;

--- a/tests/scheduling.rs
+++ b/tests/scheduling.rs
@@ -9,6 +9,7 @@ use riker_testkit::probe::{Probe, ProbeReceive};
 use chrono::{Duration as CDuration, Utc};
 use std::time::Duration;
 use uuid::Uuid;
+use futures::executor::block_on;
 
 #[derive(Clone, Debug)]
 pub struct TestProbe(ChannelProbe<(), ()>);
@@ -141,10 +142,10 @@ impl Receive<SomeMessage> for ScheduleRepeat {
 
 #[test]
 fn schedule_repeat() {
-    let sys = ActorSystem::new().unwrap();
+    let sys = block_on(ActorSystem::new()).unwrap();
 
     let props = Props::new(ScheduleRepeat::new);
-    let actor = sys.actor_of(props, "schedule-repeat").unwrap();
+    let actor = block_on(sys.actor_of(props, "schedule-repeat")).unwrap();
 
     let (probe, listen) = probe();
 

--- a/tests/scheduling.rs
+++ b/tests/scheduling.rs
@@ -35,7 +35,7 @@ impl Actor for ScheduleOnce {
     type Msg = ScheduleOnceMsg;
 
     async fn recv(&mut self, ctx: &Context<Self::Msg>, msg: Self::Msg, sender: Sender) {
-        self.receive(ctx, msg, sender);
+        self.receive(ctx, msg, sender).await;
     }
 }
 

--- a/tests/scheduling.rs
+++ b/tests/scheduling.rs
@@ -1,6 +1,8 @@
 #[macro_use]
 extern crate riker_testkit;
 
+use async_trait::async_trait;
+
 use riker::actors::*;
 
 use riker_testkit::probe::channel::{probe, ChannelProbe};
@@ -28,38 +30,41 @@ impl ScheduleOnce {
     }
 }
 
+#[async_trait]
 impl Actor for ScheduleOnce {
     type Msg = ScheduleOnceMsg;
 
-    fn recv(&mut self, ctx: &Context<Self::Msg>, msg: Self::Msg, sender: Sender) {
+    async fn recv(&mut self, ctx: &Context<Self::Msg>, msg: Self::Msg, sender: Sender) {
         self.receive(ctx, msg, sender);
     }
 }
 
+#[async_trait]
 impl Receive<TestProbe> for ScheduleOnce {
     type Msg = ScheduleOnceMsg;
 
-    fn receive(&mut self, ctx: &Context<ScheduleOnceMsg>, msg: TestProbe, _sender: Sender) {
+    async fn receive(&mut self, ctx: &Context<ScheduleOnceMsg>, msg: TestProbe, _sender: Sender) {
         self.probe = Some(msg);
         // reschedule an Empty to be sent to myself()
         ctx.schedule_once(Duration::from_millis(200), ctx.myself(), None, SomeMessage);
     }
 }
 
+#[async_trait]
 impl Receive<SomeMessage> for ScheduleOnce {
     type Msg = ScheduleOnceMsg;
 
-    fn receive(&mut self, _ctx: &Context<ScheduleOnceMsg>, _msg: SomeMessage, _sender: Sender) {
+    async fn receive(&mut self, _ctx: &Context<ScheduleOnceMsg>, _msg: SomeMessage, _sender: Sender) {
         self.probe.as_ref().unwrap().0.event(());
     }
 }
 
 #[test]
 fn schedule_once() {
-    let sys = ActorSystem::new().unwrap();
+    let sys = block_on(ActorSystem::new()).unwrap();
 
     let props = Props::new(ScheduleOnce::new);
-    let actor = sys.actor_of(props, "schedule-once").unwrap();
+    let actor = block_on(sys.actor_of(props, "schedule-once")).unwrap();
 
     let (probe, listen) = probe();
 
@@ -70,10 +75,10 @@ fn schedule_once() {
 
 #[test]
 fn schedule_at_time() {
-    let sys = ActorSystem::new().unwrap();
+    let sys = block_on(ActorSystem::new()).unwrap();
 
     let props = Props::new(ScheduleOnce::new);
-    let actor = sys.actor_of(props, "schedule-once").unwrap();
+    let actor = block_on(sys.actor_of(props, "schedule-once")).unwrap();
 
     let (probe, listen) = probe();
 
@@ -101,18 +106,20 @@ impl ScheduleRepeat {
     }
 }
 
+#[async_trait]
 impl Actor for ScheduleRepeat {
     type Msg = ScheduleRepeatMsg;
 
-    fn recv(&mut self, ctx: &Context<Self::Msg>, msg: Self::Msg, sender: Sender) {
-        self.receive(ctx, msg, sender);
+    async fn recv(&mut self, ctx: &Context<Self::Msg>, msg: Self::Msg, sender: Sender) {
+        self.receive(ctx, msg, sender).await;
     }
 }
 
+#[async_trait]
 impl Receive<TestProbe> for ScheduleRepeat {
     type Msg = ScheduleRepeatMsg;
 
-    fn receive(&mut self, ctx: &Context<Self::Msg>, msg: TestProbe, _sender: Sender) {
+    async fn receive(&mut self, ctx: &Context<Self::Msg>, msg: TestProbe, _sender: Sender) {
         self.probe = Some(msg);
         // schedule Message to be repeatedly sent to myself
         // and store the job id to cancel it later
@@ -127,10 +134,11 @@ impl Receive<TestProbe> for ScheduleRepeat {
     }
 }
 
+#[async_trait]
 impl Receive<SomeMessage> for ScheduleRepeat {
     type Msg = ScheduleRepeatMsg;
 
-    fn receive(&mut self, ctx: &Context<Self::Msg>, _msg: SomeMessage, _sender: Sender) {
+    async fn receive(&mut self, ctx: &Context<Self::Msg>, _msg: SomeMessage, _sender: Sender) {
         if self.counter == 5 {
             ctx.cancel_schedule(self.schedule_id.unwrap());
             self.probe.as_ref().unwrap().0.event(());

--- a/tests/selection.rs
+++ b/tests/selection.rs
@@ -71,7 +71,7 @@ fn select_child() {
         // select test actors through actor selection: /root/user/select-actor/*
         let sel = sys.select("select-actor").unwrap();
 
-        sel.try_tell(TestProbe(probe), None);
+        sel.try_tell(TestProbe(probe), None).await;
 
         p_assert_eq!(listen, ());
     });
@@ -95,7 +95,7 @@ fn select_child_of_child() {
 
         // select test actors through actor selection: /root/user/select-actor/*
         let sel = sys.select("select-actor/child_a").unwrap();
-        sel.try_tell(TestProbe(probe), None);
+        sel.try_tell(TestProbe(probe), None).await;
 
         // actors 'child_a' should fire a probe event
         p_assert_eq!(listen, ());
@@ -118,7 +118,7 @@ fn select_all_children_of_child() {
 
         // select relative test actors through actor selection: /root/user/select-actor/*
         let sel = sys.select("select-actor/*").unwrap();
-        sel.try_tell(TestProbe(probe.clone()), None);
+        sel.try_tell(TestProbe(probe.clone()), None).await;
 
         // actors 'child_a' and 'child_b' should both fire a probe event
         p_assert_eq!(listen, ());
@@ -126,7 +126,7 @@ fn select_all_children_of_child() {
 
         // select absolute test actors through actor selection: /root/user/select-actor/*
         let sel = sys.select("/user/select-actor/*").unwrap();
-        sel.try_tell(TestProbe(probe), None);
+        sel.try_tell(TestProbe(probe), None).await;
 
         // actors 'child_a' and 'child_b' should both fire a probe event
         p_assert_eq!(listen, ());
@@ -160,23 +160,23 @@ impl Actor for SelectTest2 {
     async fn recv(&mut self, ctx: &Context<Self::Msg>, msg: Self::Msg, _sender: Sender) {
         // up and down: ../select-actor/child_a
         let sel = ctx.select("../select-actor/child_a").unwrap();
-        sel.try_tell(msg.clone(), None);
+        sel.try_tell(msg.clone(), None).await;
 
         // child: child_a
         let sel = ctx.select("child_a").unwrap();
-        sel.try_tell(msg.clone(), None);
+        sel.try_tell(msg.clone(), None).await;
 
         // absolute: /user/select-actor/child_a
         let sel = ctx.select("/user/select-actor/child_a").unwrap();
-        sel.try_tell(msg.clone(), None);
+        sel.try_tell(msg.clone(), None).await;
 
         // // absolute all: /user/select-actor/*
         let sel = ctx.select("/user/select-actor/*").unwrap();
-        sel.try_tell(msg.clone(), None);
+        sel.try_tell(msg.clone(), None).await;
 
         // all: *
         let sel = ctx.select("*").unwrap();
-        sel.try_tell(msg, None);
+        sel.try_tell(msg, None).await;
     }
 }
 

--- a/tests/selection.rs
+++ b/tests/selection.rs
@@ -1,6 +1,8 @@
 #[macro_use]
 extern crate riker_testkit;
 
+use futures::executor::block_on;
+
 use riker::actors::*;
 
 use riker_testkit::probe::channel::{probe, ChannelProbe};
@@ -55,7 +57,7 @@ impl Actor for SelectTest {
 
 #[test]
 fn select_child() {
-    let sys = ActorSystem::new().unwrap();
+    let sys = block_on(ActorSystem::new()).unwrap();
 
     let props = Props::new(SelectTest::new);
     sys.actor_of(props, "select-actor").unwrap();
@@ -72,7 +74,7 @@ fn select_child() {
 
 #[test]
 fn select_child_of_child() {
-    let sys = ActorSystem::new().unwrap();
+    let sys = block_on(ActorSystem::new()).unwrap();
 
     let props = Props::new(SelectTest::new);
     sys.actor_of(props, "select-actor").unwrap();
@@ -93,7 +95,7 @@ fn select_child_of_child() {
 
 #[test]
 fn select_all_children_of_child() {
-    let sys = ActorSystem::new().unwrap();
+    let sys = block_on(ActorSystem::new()).unwrap();
 
     let props = Props::new(SelectTest::new);
     sys.actor_of(props, "select-actor").unwrap();
@@ -168,7 +170,7 @@ impl Actor for SelectTest2 {
 
 #[test]
 fn select_from_context() {
-    let sys = ActorSystem::new().unwrap();
+    let sys = block_on(ActorSystem::new()).unwrap();
 
     let props = Props::new(SelectTest2::new);
     let actor = sys.actor_of(props, "select-actor").unwrap();
@@ -188,7 +190,7 @@ fn select_from_context() {
 
 #[test]
 fn select_paths() {
-    let sys = ActorSystem::new().unwrap();
+    let sys = block_on(ActorSystem::new()).unwrap();
 
     assert!(sys.select("foo/").is_ok());
     assert!(sys.select("/foo/").is_ok());
@@ -244,7 +246,7 @@ fn select_paths() {
 
 // #[test]
 // fn select_no_actors() {
-//     let sys = ActorSystem::new().unwrap();
+//     let sys = block_on(ActorSystem::new()).unwrap();
 
 //     let props = Props::new(DeadLettersActor::new);
 //     let act = sys.actor_of(props, "dl-subscriber").unwrap();

--- a/tests/supervision.rs
+++ b/tests/supervision.rs
@@ -1,6 +1,8 @@
 #[macro_use]
 extern crate riker_testkit;
 
+use futures::executor::block_on;
+
 use riker::actors::*;
 
 use riker_testkit::probe::channel::{probe, ChannelProbe};
@@ -122,7 +124,7 @@ impl Receive<Panic> for RestartSup {
 
 #[test]
 fn supervision_restart_failed_actor() {
-    let sys = ActorSystem::new().unwrap();
+    let sys = block_on(ActorSystem::new()).unwrap();
 
     for i in 0..100 {
         let props = Props::new(RestartSup::new);
@@ -240,10 +242,10 @@ impl Receive<Panic> for EscRestartSup {
 
 #[test]
 fn supervision_escalate_failed_actor() {
-    let sys = ActorSystem::new().unwrap();
+    let sys = block_on(ActorSystem::new()).unwrap();
 
     let props = Props::new(EscRestartSup::new);
-    let sup = sys.actor_of(props, "supervisor").unwrap();
+    let sup = block_on(sys.actor_of(props, "supervisor")).unwrap();
 
     // Make the test actor panic
     sup.tell(Panic, None);

--- a/tests/supervision.rs
+++ b/tests/supervision.rs
@@ -117,7 +117,7 @@ impl Receive<TestProbe> for RestartSup {
     type Msg = RestartSupMsg;
 
     async fn receive(&mut self, _ctx: &Context<Self::Msg>, msg: TestProbe, sender: Sender) {
-        self.actor_to_fail.as_ref().unwrap().tell(msg, sender);
+        self.actor_to_fail.as_ref().unwrap().tell(msg, sender).await;
     }
 }
 
@@ -270,7 +270,7 @@ fn supervision_escalate_failed_actor() {
 
         let (probe, mut listen) = probe::<()>();
         std::thread::sleep(std::time::Duration::from_millis(2000));
-        sup.tell(TestProbe(probe), None);
+        sup.tell(TestProbe(probe), None).await;
         p_assert_eq!(listen, ());
         sys.print_tree();
     });

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -3,15 +3,15 @@ use riker::actors::*;
 
 #[test]
 fn system_create() {
-    assert!(ActorSystem::new().is_ok());
-    assert!(ActorSystem::with_name("valid-name").is_ok());
+    assert!(block_on(ActorSystem::new()).is_ok());
+    assert!(block_on(ActorSystem::with_name("valid-name")).is_ok());
 
-    assert!(ActorSystem::with_name("/").is_err());
-    assert!(ActorSystem::with_name("*").is_err());
-    assert!(ActorSystem::with_name("/a/b/c").is_err());
-    assert!(ActorSystem::with_name("@").is_err());
-    assert!(ActorSystem::with_name("#").is_err());
-    assert!(ActorSystem::with_name("abc*").is_err());
+    assert!(block_on(ActorSystem::with_name("/")).is_err());
+    assert!(block_on(ActorSystem::with_name("*")).is_err());
+    assert!(block_on(ActorSystem::with_name("/a/b/c")).is_err());
+    assert!(block_on(ActorSystem::with_name("@")).is_err());
+    assert!(block_on(ActorSystem::with_name("#")).is_err());
+    assert!(block_on(ActorSystem::with_name("abc*")).is_err());
 }
 
 struct ShutdownTest {
@@ -41,7 +41,7 @@ impl Actor for ShutdownTest {
 #[test]
 #[allow(dead_code)]
 fn system_shutdown() {
-    let sys = ActorSystem::new().unwrap();
+    let sys = block_on(ActorSystem::new()).unwrap();
 
     let props = Props::new_args(ShutdownTest::actor, 1);
     let _ = sys.actor_of(props, "test-actor-1").unwrap();
@@ -51,7 +51,7 @@ fn system_shutdown() {
 
 #[test]
 fn system_futures_exec() {
-    let sys = ActorSystem::new().unwrap();
+    let sys = block_on(ActorSystem::new()).unwrap();
 
     for i in 0..100 {
         let f = sys.run(async move { format!("some_val_{}", i) }).unwrap();
@@ -62,7 +62,7 @@ fn system_futures_exec() {
 
 #[test]
 fn system_futures_panic() {
-    let sys = ActorSystem::new().unwrap();
+    let sys = block_on(ActorSystem::new()).unwrap();
 
     for _ in 0..100 {
         let _ = sys
@@ -81,14 +81,14 @@ fn system_futures_panic() {
 
 #[test]
 fn system_load_app_config() {
-    let sys = ActorSystem::new().unwrap();
+    let sys = block_on(ActorSystem::new()).unwrap();
 
     assert_eq!(sys.config().get_int("app.some_setting").unwrap() as i64, 1);
 }
 
 #[test]
 fn system_builder() {
-    let sys = SystemBuilder::new().name("my-sys").create().unwrap();
+    let sys = block_on(SystemBuilder::new().name("my-sys").create()).unwrap();
 
     block_on(sys.shutdown()).unwrap();
 }

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -1,6 +1,8 @@
+use std::panic::AssertUnwindSafe;
 use async_trait::async_trait;
 use futures::executor::block_on;
 use riker::actors::*;
+use futures::FutureExt;
 
 #[test]
 fn system_create() {
@@ -73,12 +75,12 @@ fn system_futures_panic() {
         let sys = ActorSystem::new().await.unwrap();
 
         for _ in 0..100 {
-            let _ = sys
+            let f = sys
                 .run(async move {
                     panic!("// TEST PANIC // TEST PANIC // TEST PANIC //");
                 })
-                .unwrap()
-                .await;
+                .unwrap();
+            assert!(AssertUnwindSafe(f).catch_unwind().await.is_err());
         }
 
         for i in 0..100 {

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -50,7 +50,7 @@ fn system_shutdown() {
 
         let props = Props::new_args(ShutdownTest::actor, 1);
         sys.actor_of(props, "test-actor-1").await.unwrap();
-        sys.shutdown().await;
+        let _ = sys.shutdown().await;
     });
 }
 
@@ -103,6 +103,6 @@ fn system_builder() {
     block_on(async {
         let sys = SystemBuilder::new().name("my-sys").create().await.unwrap();
 
-        sys.shutdown().await;
+        let _ = sys.shutdown().await;
     });
 }


### PR DESCRIPTION
This is a proposal of changes needed for use of the futures friendly mutex and mpsc channel mentioned in #73.

Tests will not compile yet, because `Actor` trait was not updated to have async methods.

To make this work multiple api functions had to be changed to `async`. Also I have changed few traits to have `async` methods with the help of [async-trait](https://github.com/dtolnay/async-trait) crate.

@leenozara are you ok with the use of the async-trait crate?