### PR TITLE
ActorSystem::when_terminated initial implementation (#58)

### DIFF
--- a/tests/system.rs
+++ b/tests/system.rs
@@ -40,6 +40,21 @@ impl Actor for ShutdownTest {
 
 #[test]
 #[allow(dead_code)]
+fn system_when_shutdown() {
+    let sys = ActorSystem::new().unwrap();
+
+    let t = sys.when_terminated();
+
+    std::thread::spawn(move || {
+        let s = sys.shutdown();
+        block_on(s).unwrap();
+    });
+
+    block_on(t).unwrap();
+}
+
+#[test]
+#[allow(dead_code)]
 fn system_shutdown() {
     let sys = ActorSystem::new().unwrap();
 


### PR DESCRIPTION
Hello,

this pull request provides the initial implementation for the _ActorSystem::when_terminated_ function, as it was proposed in the issue (#58). 