### PR TITLE
Use slog as a logging subsystem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
-/target
+**/target
 **/*.rs.bk
 .vscode
+**/Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,13 +18,14 @@ riker-macros = { path = "riker-macros", version = "0.1" }
 bytes = "0.4"
 chrono = "0.4"
 config = "0.9"
-futures-preview = "0.3.0-alpha.16"
-log = { version = "0.4", features = ["std"] }
-rand = "0.4"
-regex = "0.2"
-uuid = { version = "0.6", features = ["v4"] }
+futures-preview = "0.3.0-alpha.19"
+rand = "0.7"
+regex = "1"
+uuid = { version = "0.7", features = ["v4"] }
 pin-utils = "0.1.0-alpha.4"
-
+slog = "2.5"
+slog-stdlog = "4.0"
+slog-scope = "4.1"
 
 [dev-dependencies]
 riker-testkit = "0.1.0"

--- a/config/riker.toml
+++ b/config/riker.toml
@@ -1,5 +1,7 @@
 debug = true
 
+# This are the default logger settings. If slog logger is used, then
+# the whole [log] section is ignored and the slog settings are used.
 [log]
 # max level to log
 level = "debug"

--- a/src/actor/actor.rs
+++ b/src/actor/actor.rs
@@ -94,9 +94,9 @@ impl<A: Actor + ?Sized> Actor for Box<A> {
 /// # use riker::actors::*;
 ///
 /// #[derive(Clone, Debug)]
-/// struct Foo;
+/// pub struct Foo;
 /// #[derive(Clone, Debug)]
-/// struct Bar;
+/// pub struct Bar;
 /// #[actor(Foo, Bar)] // <-- set our actor to receive Foo and Bar types
 /// struct MyActor;
 ///

--- a/src/kernel/kernel.rs
+++ b/src/kernel/kernel.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use futures::{channel::mpsc::channel, task::SpawnExt, StreamExt};
-use log::warn;
+use slog::warn;
 
 use crate::{
     actor::actor_cell::ExtendedCell,
@@ -106,7 +106,7 @@ fn restart_actor<A>(
             sys.publish_event(ActorRestarted { actor: actor_ref }.into());
         }
         Err(_) => {
-            warn!("Actor failed to restart: {:?}", actor_ref);
+            warn!(sys.log(), "Actor failed to restart: {:?}", actor_ref);
         }
     }
 }

--- a/src/kernel/mailbox.rs
+++ b/src/kernel/mailbox.rs
@@ -5,7 +5,6 @@ use std::sync::{
 use std::thread;
 
 use config::Config;
-use log::trace;
 
 use crate::{
     actor::actor_cell::ExtendedCell,
@@ -291,7 +290,6 @@ fn handle_init<A>(
 ) where
     A: Actor,
 {
-    trace!("ACTOR INIT");
     actor.as_mut().unwrap().pre_start(ctx);
     mbox.set_suspended(false);
 

--- a/src/kernel/provider.rs
+++ b/src/kernel/provider.rs
@@ -1,4 +1,4 @@
-use log::trace;
+use slog::trace;
 use std::{
     collections::HashSet,
     sync::{Arc, Mutex},
@@ -11,10 +11,12 @@ use crate::{
     system::{system::SysActors, ActorSystem, SystemMsg},
     validate::validate_name,
 };
+use slog::Logger;
 
 #[derive(Clone)]
 pub struct Provider {
     inner: Arc<Mutex<ProviderInner>>,
+    log: Logger,
 }
 
 struct ProviderInner {
@@ -23,7 +25,7 @@ struct ProviderInner {
 }
 
 impl Provider {
-    pub fn new() -> Self {
+    pub fn new(log: Logger) -> Self {
         let inner = ProviderInner {
             paths: HashSet::new(),
             counter: 100, // ActorIds start at 100
@@ -31,6 +33,7 @@ impl Provider {
 
         Provider {
             inner: Arc::new(Mutex::new(inner)),
+            log,
         }
     }
 
@@ -47,7 +50,7 @@ impl Provider {
         validate_name(name)?;
 
         let path = ActorPath::new(&format!("{}/{}", parent.path(), name));
-        trace!("Attempting to create actor at: {}", path);
+        trace!(sys.log(), "Attempting to create actor at: {}", path);
 
         let uid = self.register(&path)?;
 
@@ -148,7 +151,7 @@ fn root(sys: &ActorSystem) -> BasicActorRef {
     let bigbang = BasicActorRef::new(bb_cell);
 
     // root
-    let props: BoxActorProd<Guardian> = Props::new_args(Guardian::new, "root".to_string());
+    let props: BoxActorProd<Guardian> = Guardian::props("root".to_string(), sys.log());
     let (sender, sys_sender, mb) = mailbox::<SystemMsg>(100);
 
     let cell = ExtendedCell::new(
@@ -183,7 +186,7 @@ fn guardian(
         host: Arc::new("localhost".to_string()),
     };
 
-    let props: BoxActorProd<Guardian> = Props::new_args(Guardian::new, name.to_string());
+    let props: BoxActorProd<Guardian> = Guardian::props(name.to_string(), sys.log());
     let (sender, sys_sender, mb) = mailbox::<SystemMsg>(100);
 
     let cell = ExtendedCell::new(
@@ -208,13 +211,18 @@ fn guardian(
 
 struct Guardian {
     name: String,
+    log: Logger,
 }
 
 impl Guardian {
-    fn new(name: String) -> Self {
-        let actor = Guardian { name };
+    fn new((name, log): (String, Logger)) -> Self {
+        let actor = Guardian { name, log };
 
         actor
+    }
+
+    fn props(name: String, logger: Logger) -> BoxActorProd<Guardian> {
+        Props::new_args(Guardian::new, (name, logger))
     }
 }
 
@@ -224,6 +232,6 @@ impl Actor for Guardian {
     fn recv(&mut self, _: &Context<Self::Msg>, _: Self::Msg, _: Option<BasicActorRef>) {}
 
     fn post_stop(&mut self) {
-        trace!("{} guardian stopped", self.name);
+        trace!(self.log, "{} guardian stopped", self.name);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,9 +2,6 @@
 
 // #![allow(warnings)] // toggle for easier compile error fixing
 
-#[allow(unused_imports)]
-extern crate log;
-
 mod validate;
 
 pub mod actor;

--- a/src/system/logger.rs
+++ b/src/system/logger.rs
@@ -1,111 +1,11 @@
 use config::Config;
-use log;
-use log::{info, Level};
-
+use slog::{info, Drain, Logger, Never, OwnedKVList, Record, Level, o};
+use std::str::FromStr;
 use crate::actor::{
     Actor, ActorRef, All, BasicActorRef, BoxActorProd, ChannelMsg, Context, DeadLetter, Props,
     Subscribe, Tell,
 };
 
-pub type LogActor = Box<dyn Actor<Msg = LogEntry> + Send>;
-
-#[derive(Clone)]
-pub struct Logger {
-    level: Level,
-    actor: ActorRef<LogEntry>,
-}
-
-impl Logger {
-    pub fn init(level: Level, actor: ActorRef<LogEntry>) -> Self {
-        let logger = Logger { level, actor };
-
-        let _ = log::set_boxed_logger(Box::new(logger.clone())); // result is Err for some reason (.unwrap() panics)
-        log::set_max_level(level.to_level_filter());
-
-        logger
-    }
-}
-
-impl log::Log for Logger {
-    fn enabled(&self, metadata: &log::Metadata) -> bool {
-        metadata.level() <= self.level
-    }
-
-    fn log(&self, record: &log::Record) {
-        self.actor.tell(LogEntry::from(record), None);
-    }
-
-    fn flush(&self) {}
-}
-
-#[derive(Clone, Debug)]
-pub struct LogEntry {
-    pub level: log::Level,
-    pub module: Option<String>,
-    pub body: String,
-}
-
-impl<'a> From<&'a log::Record<'a>> for LogEntry {
-    fn from(record: &log::Record) -> Self {
-        LogEntry {
-            level: record.level(),
-            module: record.module_path().map(|m| m.to_string()),
-            body: format!("{}", record.args()),
-        }
-    }
-}
-
-// default logger
-pub struct SimpleLogger {
-    cfg: LoggerConfig,
-}
-
-impl SimpleLogger {
-    pub fn actor(cfg: LoggerConfig) -> LogActor {
-        let a = SimpleLogger { cfg };
-
-        Box::new(a)
-    }
-
-    pub fn props(cfg: LoggerConfig) -> BoxActorProd<LogActor> {
-        Props::new_args(SimpleLogger::actor, cfg)
-    }
-}
-
-impl Actor for SimpleLogger {
-    type Msg = LogEntry;
-
-    fn recv(&mut self, _: &Context<LogEntry>, entry: LogEntry, _: Option<BasicActorRef>) {
-        let now = chrono::Utc::now();
-        let f_match: Vec<&String> = self
-            .cfg
-            .filter
-            .iter()
-            .filter(|f| {
-                entry
-                    .module
-                    .as_ref()
-                    .map(|m| m.contains(*f))
-                    .unwrap_or(false)
-            })
-            .collect();
-        if f_match.is_empty() {
-            // note:
-            // println! below has replaced rt_println! from runtime-fmt crate.
-            // The log format is fixed as "{date} {time} {level} [{module}] {body}".
-            // It's not clear if runtime-fmt is maintained any longer as so we'll
-            // attempt to find an alternative to provide configurable formatting.
-            println!(
-                "{} {} {} [{}] {}",
-                now.format(&self.cfg.date_fmt),
-                now.format(&self.cfg.time_fmt),
-                entry.level,
-                entry.module.unwrap_or_default(),
-                entry.body
-            );
-        }
-    }
-}
 
 #[derive(Clone)]
 pub struct LoggerConfig {
@@ -113,6 +13,7 @@ pub struct LoggerConfig {
     date_fmt: String,
     log_fmt: String,
     filter: Vec<String>,
+    level: Level
 }
 
 impl<'a> From<&'a Config> for LoggerConfig {
@@ -127,24 +28,75 @@ impl<'a> From<&'a Config> for LoggerConfig {
                 .into_iter()
                 .map(|e| e.to_string())
                 .collect(),
+            level: config
+                .get_str("log.level")
+                .map(|l| Level::from_str(&l).unwrap_or(Level::Info))
+                .unwrap_or(Level::Info)
         }
     }
 }
 
-// pub type DLActor = Box<dyn Actor<Msg=DeadLetter, Evt=()> + Send>;
+pub(crate) fn default_log(cfg: &Config) -> Logger {
+    let cfg = LoggerConfig::from(cfg);
+
+    let drain = DefaultConsoleLogger::new(cfg.clone()).filter_level(cfg.level).fuse();
+    let logger = Logger::root(drain, o!());
+
+    let _scope_guard = slog_scope::set_global_logger(logger.clone());
+    let _log_guard = slog_stdlog::init();   // will not call `.unwrap()` because this might be called more than once
+
+    logger
+}
+
+struct DefaultConsoleLogger {
+    cfg: LoggerConfig
+}
+
+impl DefaultConsoleLogger {
+    fn new(cfg: LoggerConfig) -> Self {
+        DefaultConsoleLogger { cfg }
+    }
+}
+
+impl Drain for DefaultConsoleLogger {
+    type Ok = ();
+    type Err = Never;
+
+    fn log(&self, record: &Record, _values: &OwnedKVList) -> Result<Self::Ok, Self::Err> {
+        let now = chrono::Utc::now();
+        let filter_match = self.cfg.filter.iter()
+            .any(|f| record.module().contains(f));
+        if !filter_match {
+            // note:
+            // println! below has replaced rt_println! from runtime-fmt crate.
+            // The log format is fixed as "{date} {time} {level} [{module}] {body}".
+            // It's not clear if runtime-fmt is maintained any longer as so we'll
+            // attempt to find an alternative to provide configurable formatting.
+            println!("{} {} {} [{}] {}",
+                     now.format(&self.cfg.date_fmt),
+                     now.format(&self.cfg.time_fmt),
+                     record.level().as_short_str(),
+                     record.module(),
+                     record.msg());
+        }
+
+        Ok(())
+    }
+}
 
 /// Simple actor that subscribes to the dead letters channel and logs using the default logger
 pub struct DeadLetterLogger {
     dl_chan: ActorRef<ChannelMsg<DeadLetter>>,
+    logger: Logger,
 }
 
 impl DeadLetterLogger {
-    fn new(dl_chan: ActorRef<ChannelMsg<DeadLetter>>) -> Self {
-        DeadLetterLogger { dl_chan }
+    fn new((dl_chan, logger): (ActorRef<ChannelMsg<DeadLetter>>, Logger)) -> Self {
+        DeadLetterLogger { dl_chan, logger }
     }
 
-    pub fn props(dl_chan: &ActorRef<ChannelMsg<DeadLetter>>) -> BoxActorProd<DeadLetterLogger> {
-        Props::new_args(DeadLetterLogger::new, dl_chan.clone())
+    pub fn props(dl_chan: &ActorRef<ChannelMsg<DeadLetter>>, logger: Logger) -> BoxActorProd<DeadLetterLogger> {
+        Props::new_args(DeadLetterLogger::new, (dl_chan.clone(), logger))
     }
 }
 
@@ -163,8 +115,7 @@ impl Actor for DeadLetterLogger {
     }
 
     fn recv(&mut self, _: &Context<Self::Msg>, msg: Self::Msg, _: Option<BasicActorRef>) {
-        info!(
-            "DeadLetter: {:?} => {:?} ({:?})",
+        info!(self.logger, "DeadLetter: {:?} => {:?} ({:?})",
             msg.sender, msg.recipient, msg.msg
         )
     }

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -8,7 +8,6 @@ use crate::actor::BasicActorRef;
 
 // Public riker::system API (plus the pub data types in this file)
 pub use self::{
-    logger::LogEntry,
     system::{ActorSystem, Run, SystemBuilder},
     timer::{BasicTimer, Timer},
 };

--- a/src/system/system.rs
+++ b/src/system/system.rs
@@ -159,7 +159,7 @@ impl ActorSystem {
 
         // Until the logger has started, use println
         if debug {
-            println!("Starting actor system: System[{}]", name);
+            debug!(log, "Starting actor system: System[{}]", name);
         }
 
         let prov = Provider::new(log.clone());

--- a/src/system/system.rs
+++ b/src/system/system.rs
@@ -1,7 +1,6 @@
 use std::{
     fmt,
     ops::Deref,
-    str::FromStr,
     sync::{Arc, Mutex},
     time::{Duration, SystemTime},
 };
@@ -15,7 +14,6 @@ use futures::{
     task::{SpawnError, SpawnExt},
     Future,
 };
-use log::{debug, Level};
 use rand;
 use uuid::Uuid;
 
@@ -29,6 +27,7 @@ use crate::{
     validate::{validate_name, InvalidPath},
     AnyMessage, Message,
 };
+use slog::{debug, Logger};
 
 // 0. error results on any
 // 1. visibility
@@ -45,7 +44,7 @@ pub struct ProtoSystem {
 pub struct SystemBuilder {
     name: Option<String>,
     cfg: Option<Config>,
-    log: Option<BoxActorProd<LogActor>>,
+    log: Option<Logger>,
     exec: Option<ThreadPool>,
 }
 
@@ -60,11 +59,12 @@ impl SystemBuilder {
     }
 
     pub fn create(self) -> Result<ActorSystem, SystemError> {
-        let cfg = self.cfg.unwrap_or(load_config());
-        let exec = self.exec.unwrap_or(default_exec(&cfg));
-        let log = self.log.unwrap_or(default_log(&cfg));
+        let name = self.name.unwrap_or_else(|| "riker".into());
+        let cfg = self.cfg.unwrap_or_else(|| load_config());
+        let exec = self.exec.unwrap_or_else(|| default_exec(&cfg));
+        let log = self.log.unwrap_or_else(|| default_log(&cfg));
 
-        ActorSystem::create(self.name.as_ref().unwrap(), exec, log, cfg)
+        ActorSystem::create(&name, exec, log, cfg)
     }
 
     pub fn name(self, name: &str) -> Self {
@@ -87,6 +87,13 @@ impl SystemBuilder {
             ..self
         }
     }
+
+    pub fn log(self, log: Logger) -> Self {
+        SystemBuilder {
+            log: Some(log),
+            ..self
+        }
+    }
 }
 
 /// The actor runtime and common services coordinator
@@ -101,7 +108,7 @@ impl SystemBuilder {
 pub struct ActorSystem {
     proto: Arc<ProtoSystem>,
     sys_actors: Option<SysActors>,
-    log: Option<Logger>,
+    log: Logger,
     debug: bool,
     pub exec: ThreadPool,
     pub timer: TimerRef,
@@ -143,7 +150,7 @@ impl ActorSystem {
     fn create(
         name: &str,
         exec: ThreadPool,
-        log: BoxActorProd<LogActor>,
+        log: Logger,
         cfg: Config,
     ) -> Result<ActorSystem, SystemError> {
         validate_name(name).map_err(|_| SystemError::InvalidName(name.into()))?;
@@ -155,7 +162,7 @@ impl ActorSystem {
             println!("Starting actor system: System[{}]", name);
         }
 
-        let prov = Provider::new();
+        let prov = Provider::new(log.clone());
         let timer = BasicTimer::start(&cfg);
 
         // 1. create proto system
@@ -173,7 +180,7 @@ impl ActorSystem {
             proto: Arc::new(proto),
             debug,
             exec,
-            log: None,
+            log,
             // event_store: None,
             timer,
             sys_channels: None,
@@ -185,19 +192,16 @@ impl ActorSystem {
         let sys_actors = create_root(&sys);
         sys.sys_actors = Some(sys_actors);
 
-        // 4. start logger
-        sys.log = Some(logger(&prov, &sys, &cfg, log)?);
-
-        // 5. start system channels
+        // 4. start system channels
         sys.sys_channels = Some(sys_channels(&prov, &sys)?);
 
-        // 6. start dead letter logger
-        let props = DeadLetterLogger::props(sys.dead_letters());
+        // 5. start dead letter logger
+        let props = DeadLetterLogger::props(sys.dead_letters(), sys.log());
         let _dl_logger = sys_actor_of(&prov, &sys, props, "dl_logger")?;
 
         sys.complete_start();
 
-        debug!("Actor system [{}] [{}] started", sys.id(), name);
+        debug!(sys.log, "Actor system [{}] [{}] started", sys.id(), name);
 
         Ok(sys)
     }
@@ -315,6 +319,11 @@ impl ActorSystem {
     {
         self.provider
             .create_actor(props, name, &self.sys_root(), self)
+    }
+
+    #[inline]
+    pub fn log(&self) -> Logger {
+        self.log.clone()
     }
 
     /// Shutdown the actor system
@@ -439,9 +448,9 @@ impl Timer for ActorSystem {
         let job = RepeatJob {
             id: id.clone(),
             send_at: SystemTime::now() + initial_delay,
-            interval: interval,
+            interval,
             receiver: receiver.into(),
-            sender: sender,
+            sender,
             msg: AnyMessage::new(msg, false),
         };
 
@@ -467,7 +476,7 @@ impl Timer for ActorSystem {
             id: id.clone(),
             send_at: SystemTime::now() + delay,
             receiver: receiver.into(),
-            sender: sender,
+            sender,
             msg: AnyMessage::new(msg, true),
         };
 
@@ -495,7 +504,7 @@ impl Timer for ActorSystem {
             id: id.clone(),
             send_at: time,
             receiver: receiver.into(),
-            sender: sender,
+            sender,
             msg: AnyMessage::new(msg, true),
         };
 
@@ -521,22 +530,6 @@ where
 {
     prov.create_actor(props, name, &sys.sys_root(), sys)
         .map_err(|_| SystemError::ModuleFailed(name.into()))
-}
-
-fn logger(
-    prov: &Provider,
-    sys: &ActorSystem,
-    cfg: &Config,
-    props: BoxActorProd<LogActor>,
-) -> Result<Logger, SystemError> {
-    let logger = sys_actor_of(prov, sys, props, "logger")?;
-
-    let level = cfg
-        .get_str("log.level")
-        .map(|l| Level::from_str(&l))
-        .unwrap()
-        .unwrap();
-    Ok(Logger::init(level, logger))
 }
 
 fn sys_channels(prov: &Provider, sys: &ActorSystem) -> Result<SysChannels, SystemError> {
@@ -589,11 +582,6 @@ fn default_exec(cfg: &Config) -> ThreadPool {
         .name_prefix("pool-thread-#")
         .create()
         .unwrap()
-}
-
-fn default_log(cfg: &Config) -> BoxActorProd<LogActor> {
-    let cfg = LoggerConfig::from(cfg);
-    SimpleLogger::props(cfg)
 }
 
 #[derive(Clone)]

--- a/tests/logger.rs
+++ b/tests/logger.rs
@@ -1,0 +1,53 @@
+use futures::executor::block_on;
+
+use riker::actors::*;
+use slog::{Logger, Fuse, o};
+
+mod common {
+    use std::{fmt, result};
+
+    use slog::*;
+
+    pub struct PrintlnSerializer;
+
+    impl Serializer for PrintlnSerializer {
+        fn emit_arguments(&mut self, key: Key, val: &fmt::Arguments) -> Result {
+            print!(", {}={}", key, val);
+            Ok(())
+        }
+    }
+
+    pub struct PrintlnDrain;
+
+    impl Drain for PrintlnDrain {
+        type Ok = ();
+        type Err = ();
+
+        fn log(
+            &self,
+            record: &Record,
+            values: &OwnedKVList,
+        ) -> result::Result<Self::Ok, Self::Err> {
+
+            print!("{}", record.msg());
+
+            record
+                .kv()
+                .serialize(record, &mut PrintlnSerializer)
+                .unwrap();
+            values.serialize(record, &mut PrintlnSerializer).unwrap();
+
+            println!();
+            Ok(())
+        }
+    }
+}
+
+#[test]
+fn system_create_with_slog() {
+    let log = Logger::root(Fuse(common::PrintlnDrain), o!("version" => "v1", "run_env" => "test"));
+    let sys = SystemBuilder::new()
+        .log(log)
+        .create().unwrap();
+    block_on(sys.shutdown()).unwrap();
+}


### PR DESCRIPTION
This PR replaces `log` crate by the `slog` crate. All code was written with a backward compatibility in mind. When `slog::Logger` is not passed to actor system via the `SystemBuilder`, then behavior and log messages format stays the same as was before this PR.

Example of how `slog` can be passed to riker.
```rust
#[macro_use]
extern crate slog;
extern crate sloggers;

use sloggers::Build;
use sloggers::terminal::{TerminalLoggerBuilder, Destination};
use sloggers::types::Severity;

let mut builder = TerminalLoggerBuilder::new();
builder.level(Severity::Debug);
builder.destination(Destination::Stderr);

let logger = builder.build().unwrap();
let sys = SystemBuilder::new()
    .log(logger)
    .create().unwrap();
```