### PR TITLE
Use Instant for time tracking instead of SystemTime

### DIFF
--- a/src/system/system.rs
+++ b/src/system/system.rs
@@ -3,7 +3,7 @@ use std::{
     ops::Deref,
     str::FromStr,
     sync::{Arc, Mutex},
-    time::{Duration, SystemTime},
+    time::{Duration, Instant},
 };
 
 use chrono::prelude::*;
@@ -438,7 +438,7 @@ impl Timer for ActorSystem {
 
         let job = RepeatJob {
             id: id.clone(),
-            send_at: SystemTime::now() + initial_delay,
+            send_at: Instant::now() + initial_delay,
             interval: interval,
             receiver: receiver.into(),
             sender: sender,
@@ -465,7 +465,7 @@ impl Timer for ActorSystem {
 
         let job = OnceJob {
             id: id.clone(),
-            send_at: SystemTime::now() + delay,
+            send_at: Instant::now() + delay,
             receiver: receiver.into(),
             sender: sender,
             msg: AnyMessage::new(msg, true),
@@ -486,14 +486,15 @@ impl Timer for ActorSystem {
         T: Message + Into<M>,
         M: Message,
     {
-        let time = SystemTime::UNIX_EPOCH + Duration::from_secs(time.timestamp() as u64);
+        let delay = std::cmp::max(time.timestamp() - Utc::now().timestamp(), 0 as i64);
+        let delay = Duration::from_secs(delay as u64);
 
         let id = Uuid::new_v4();
         let msg: M = msg.into();
 
         let job = OnceJob {
             id: id.clone(),
-            send_at: time,
+            send_at: Instant::now() + delay,
             receiver: receiver.into(),
             sender: sender,
             msg: AnyMessage::new(msg, true),


### PR DESCRIPTION
This MR introduces `Instant` for time tracking in the timer, replacing the before used `SystemTime`. 
Closes #42. 