### PR TITLE
Address `cargo clippy` errors and simple warnings

### DIFF
--- a/src/actor/actor_cell.rs
+++ b/src/actor/actor_cell.rs
@@ -521,7 +521,7 @@ where
     Msg: Message,
 {
     fn select(&self, path: &str) -> Result<ActorSelection, InvalidPath> {
-        let (anchor, path_str) = if path.starts_with("/") {
+        let (anchor, path_str) = if path.starts_with('/') {
             let anchor = self.system.user_root().clone();
             let anchor_path = format!("{}/", anchor.path().deref().clone());
             let path = path.to_string().replace(&anchor_path, "");
@@ -571,15 +571,15 @@ where
         let msg: M = msg.into();
 
         let job = RepeatJob {
-            id: id.clone(),
+            id,
             send_at: SystemTime::now() + initial_delay,
-            interval: interval,
+            interval,
             receiver: receiver.into(),
-            sender: sender,
+            sender,
             msg: AnyMessage::new(msg, false),
         };
 
-        let _ = self.system.timer.send(Job::Repeat(job)).unwrap();
+        self.system.timer.send(Job::Repeat(job)).unwrap();
         id
     }
 
@@ -598,14 +598,14 @@ where
         let msg: M = msg.into();
 
         let job = OnceJob {
-            id: id.clone(),
+            id,
             send_at: SystemTime::now() + delay,
             receiver: receiver.into(),
-            sender: sender,
+            sender,
             msg: AnyMessage::new(msg, true),
         };
 
-        let _ = self.system.timer.send(Job::Once(job)).unwrap();
+        self.system.timer.send(Job::Once(job)).unwrap();
         id
     }
 
@@ -626,14 +626,14 @@ where
         let msg: M = msg.into();
 
         let job = OnceJob {
-            id: id.clone(),
+            id,
             send_at: time,
             receiver: receiver.into(),
-            sender: sender,
+            sender,
             msg: AnyMessage::new(msg, true),
         };
 
-        let _ = self.system.timer.send(Job::Once(job)).unwrap();
+        self.system.timer.send(Job::Once(job)).unwrap();
         id
     }
 
@@ -688,8 +688,8 @@ impl<'a> Iterator for ChildrenIterator<'a> {
 
     fn next(&mut self) -> Option<Self::Item> {
         let actors = self.children.actors.read().unwrap();
-        let actor = actors.values().skip(self.position).next();
+        let actor = actors.values().nth(self.position);
         self.position += 1;
-        actor.map(|a| a.clone())
+        actor.cloned()
     }
 }

--- a/src/actor/actor_cell.rs
+++ b/src/actor/actor_cell.rs
@@ -13,8 +13,6 @@ use chrono::prelude::*;
 use futures::{future::RemoteHandle, task::SpawnError, Future};
 use uuid::Uuid;
 
-use rand;
-
 use crate::{
     actor::*,
     kernel::{

--- a/src/actor/channel.rs
+++ b/src/actor/channel.rs
@@ -2,7 +2,7 @@
 
 use std::{
     collections::HashMap,
-    hash::{Hash, Hasher},
+    hash::Hash,
 };
 
 use crate::{

--- a/src/actor/mod.rs
+++ b/src/actor/mod.rs
@@ -53,13 +53,13 @@ impl<T> Error for MsgError<T> {
 
 impl<T> fmt::Display for MsgError<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str(self.description())
+        f.write_str(&self.to_string())
     }
 }
 
 impl<T> fmt::Debug for MsgError<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str(self.description())
+        f.write_str(&self.to_string())
     }
 }
 
@@ -82,13 +82,13 @@ impl<T> Error for TryMsgError<T> {
 
 impl<T> fmt::Display for TryMsgError<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str(self.description())
+        f.write_str(&self.to_string())
     }
 }
 
 impl<T> fmt::Debug for TryMsgError<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str(self.description())
+        f.write_str(&self.to_string())
     }
 }
 
@@ -116,13 +116,13 @@ impl Error for CreateError {
 impl fmt::Display for CreateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            CreateError::Panicked => f.write_str(self.description()),
-            CreateError::System => f.write_str(self.description()),
+            CreateError::Panicked => f.write_str(&self.to_string()),
+            CreateError::System => f.write_str(&self.to_string()),
             CreateError::InvalidName(ref name) => {
-                f.write_str(&format!("{} ({})", self.description(), name))
+                f.write_str(&format!("{} ({})", self.to_string(), name))
             }
             CreateError::AlreadyExists(ref path) => {
-                f.write_str(&format!("{} ({})", self.description(), path))
+                f.write_str(&format!("{} ({})", self.to_string(), path))
             }
         }
     }
@@ -130,7 +130,7 @@ impl fmt::Display for CreateError {
 
 impl fmt::Debug for CreateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str(self.description())
+        f.write_str(&self.to_string())
     }
 }
 
@@ -151,12 +151,12 @@ impl Error for RestartError {
 
 impl fmt::Display for RestartError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str(self.description())
+        f.write_str(&self.to_string())
     }
 }
 
 impl fmt::Debug for RestartError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str(self.description())
+        f.write_str(&self.to_string())
     }
 }

--- a/src/actor/props.rs
+++ b/src/actor/props.rs
@@ -213,7 +213,7 @@ where
     type Actor = A;
 
     fn produce(&self) -> A {
-        let ref f = self.creator;
+        let f = &self.creator;
         f()
     }
 }
@@ -262,7 +262,7 @@ where
     type Actor = A;
 
     fn produce(&self) -> A {
-        let ref f = self.creator;
+        let f = &self.creator;
         let args = self.args.clone();
         f(args)
     }

--- a/src/actor/selection.rs
+++ b/src/actor/selection.rs
@@ -98,7 +98,7 @@ impl ActorSelection {
                     }
                 }
                 Some(&Selection::ChildName(ref name)) => {
-                    let child = anchor.children().filter({ |c| c.name() == name }).last();
+                    let child = anchor.children().filter(|c| c.name() == name).last();
                     if path_vec.peek().is_none() {
                         if let Some(actor_ref) = child {
                             actor_ref.try_tell(msg, sender.clone()).unwrap();
@@ -158,7 +158,7 @@ impl ActorSelection {
                     }
                 }
                 Some(&Selection::ChildName(ref name)) => {
-                    let child = anchor.children().filter({ |c| c.name() == name }).last();
+                    let child = anchor.children().filter(|c| c.name() == name).last();
                     if path_vec.peek().is_none() {
                         if let Some(actor_ref) = child {
                             actor_ref.try_tell(msg, sender.clone()).unwrap();

--- a/src/actor/selection.rs
+++ b/src/actor/selection.rs
@@ -51,9 +51,9 @@ impl ActorSelection {
             .split_terminator('/')
             .map({
                 |seg| match seg {
-                    ".." => Selection::SelectParent,
-                    "*" => Selection::SelectAllChildren,
-                    name => Selection::SelectChildName(name.to_string()),
+                    ".." => Selection::Parent,
+                    "*" => Selection::AllChildren,
+                    name => Selection::ChildName(name.to_string()),
                 }
             })
             .collect();
@@ -76,7 +76,7 @@ impl ActorSelection {
             mut path_vec: Peekable<I>,
             msg: Msg,
             sender: &Sender,
-            path: &String,
+            path: &str,
         ) where
             I: Iterator<Item = &'a Selection>,
             Msg: Message,
@@ -84,7 +84,7 @@ impl ActorSelection {
             let seg = path_vec.next();
 
             match seg {
-                Some(&Selection::SelectParent) => {
+                Some(&Selection::Parent) => {
                     if path_vec.peek().is_none() {
                         let parent = anchor.parent();
                         let _ = parent.try_tell(msg, sender.clone());
@@ -92,15 +92,17 @@ impl ActorSelection {
                         walk(&anchor.parent(), path_vec, msg, sender, path);
                     }
                 }
-                Some(&Selection::SelectAllChildren) => {
+                Some(&Selection::AllChildren) => {
                     for child in anchor.children() {
                         let _ = child.try_tell(msg.clone(), sender.clone());
                     }
                 }
-                Some(&Selection::SelectChildName(ref name)) => {
+                Some(&Selection::ChildName(ref name)) => {
                     let child = anchor.children().filter({ |c| c.name() == name }).last();
-                    if path_vec.peek().is_none() && child.is_some() {
-                        let _ = child.unwrap().try_tell(msg, sender.clone());
+                    if path_vec.peek().is_none() {
+                        if let Some(actor_ref) = child {
+                            actor_ref.try_tell(msg, sender.clone()).unwrap();
+                        }
                     } else if path_vec.peek().is_some() && child.is_some() {
                         walk(
                             &child.as_ref().unwrap(),
@@ -135,14 +137,14 @@ impl ActorSelection {
             mut path_vec: Peekable<I>,
             msg: SystemMsg,
             sender: &Sender,
-            path: &String,
+            path: &str,
         ) where
             I: Iterator<Item = &'a Selection>,
         {
             let seg = path_vec.next();
 
             match seg {
-                Some(&Selection::SelectParent) => {
+                Some(&Selection::Parent) => {
                     if path_vec.peek().is_none() {
                         let parent = anchor.parent();
                         parent.sys_tell(msg);
@@ -150,15 +152,17 @@ impl ActorSelection {
                         walk(&anchor.parent(), path_vec, msg, sender, path);
                     }
                 }
-                Some(&Selection::SelectAllChildren) => {
+                Some(&Selection::AllChildren) => {
                     for child in anchor.children() {
                         child.sys_tell(msg.clone());
                     }
                 }
-                Some(&Selection::SelectChildName(ref name)) => {
+                Some(&Selection::ChildName(ref name)) => {
                     let child = anchor.children().filter({ |c| c.name() == name }).last();
-                    if path_vec.peek().is_none() && child.is_some() {
-                        child.unwrap().sys_tell(msg);
+                    if path_vec.peek().is_none() {
+                        if let Some(actor_ref) = child {
+                            actor_ref.try_tell(msg, sender.clone()).unwrap();
+                        }
                     } else if path_vec.peek().is_some() && child.is_some() {
                         walk(
                             &child.as_ref().unwrap(),
@@ -189,9 +193,9 @@ impl ActorSelection {
 
 #[derive(Debug)]
 enum Selection {
-    SelectParent,
-    SelectChildName(String),
-    SelectAllChildren,
+    Parent,
+    ChildName(String),
+    AllChildren,
 }
 
 pub trait ActorSelectionFactory {

--- a/src/kernel/kernel_ref.rs
+++ b/src/kernel/kernel_ref.rs
@@ -62,7 +62,7 @@ where
 
             Ok(())
         }
-        Err(e) => Err(MsgError::new(e.msg.into())),
+        Err(e) => Err(MsgError::new(e.msg)),
     }
 }
 

--- a/src/kernel/mailbox.rs
+++ b/src/kernel/mailbox.rs
@@ -264,13 +264,8 @@ fn process_sys_msgs<A>(
     // from being processed by staging them in a Vec.
     // This prevents during actor restart.
     let mut sys_msgs: Vec<Envelope<SystemMsg>> = Vec::new();
-    loop {
-        match mbox.sys_try_dequeue() {
-            Ok(sys_msg) => {
-                sys_msgs.push(sys_msg);
-            }
-            Err(_) => break,
-        }
+    while let Ok(sys_msg) = mbox.sys_try_dequeue() {
+        sys_msgs.push(sys_msg);
     }
 
     for msg in sys_msgs.into_iter() {
@@ -367,29 +362,20 @@ pub fn flush_to_deadletters<Msg>(mbox: &Mailbox<Msg>, actor: &BasicActorRef, sys
 where
     Msg: Message,
 {
-    loop {
-        match mbox.try_dequeue() {
-            Ok(msg) => match (msg.msg, msg.sender) {
-                (msg, sender) => {
-                    let dl = DeadLetter {
-                        msg: format!("{:?}", msg),
-                        sender: sender,
-                        recipient: actor.clone(),
-                    };
+    while let Ok(Envelope { msg, sender }) = mbox.try_dequeue() {
+        let dl = DeadLetter {
+            msg: format!("{:?}", msg),
+            sender,
+            recipient: actor.clone(),
+        };
 
-                    sys.dead_letters().tell(
-                        Publish {
-                            topic: "dead_letter".into(),
-                            msg: dl,
-                        },
-                        None,
-                    );
-                }
+        sys.dead_letters().tell(
+            Publish {
+                topic: "dead_letter".into(),
+                msg: dl,
             },
-            Err(_) => {
-                break;
-            }
-        }
+            None,
+        );
     }
 }
 

--- a/src/kernel/mailbox.rs
+++ b/src/kernel/mailbox.rs
@@ -230,13 +230,18 @@ fn process_msgs<A>(
         if count < mbox.msg_process_limit() {
             match mbox.try_dequeue() {
                 Ok(msg) => {
-                    match (msg.msg, msg.sender) {
-                        (msg, sender) => {
-                            actor.as_mut().unwrap().recv(ctx, msg, sender);
-                            process_sys_msgs(&mbox, &ctx, cell, actor);
-                        }
-                        // (ActorMsg::Identify, sender) => handle_identify(sender, cell),
-                    }
+                    let (msg, sender) = (msg.msg, msg.sender);
+                    actor.as_mut().unwrap().recv(ctx, msg, sender);
+                    process_sys_msgs(&mbox, &ctx, cell, actor);
+                    
+
+                    // match (msg.msg, msg.sender) {
+                    //     (msg, sender) => {
+                    //         actor.as_mut().unwrap().recv(ctx, msg, sender);
+                    //         process_sys_msgs(&mbox, &ctx, cell, actor);
+                    //     }
+                    //     // (ActorMsg::Identify, sender) => handle_identify(sender, cell),
+                    // }
 
                     count += 1;
                 }

--- a/src/kernel/provider.rs
+++ b/src/kernel/provider.rs
@@ -62,13 +62,13 @@ impl Provider {
 
         let cell = ExtendedCell::new(
             uri.uid,
-            uri.clone(),
+            uri,
             Some(parent.clone()),
             sys,
             // None,/*perconf*/
             Arc::new(sender.clone()),
-            sys_sender.clone(),
-            sender.clone(),
+            sys_sender,
+            sender,
         );
 
         let k = kernel(props, cell.clone(), mb, sys)?;
@@ -153,13 +153,13 @@ fn root(sys: &ActorSystem) -> BasicActorRef {
 
     let cell = ExtendedCell::new(
         uri.uid,
-        uri.clone(),
-        Some(bigbang.clone()),
+        uri,
+        Some(bigbang),
         sys,
         // None,/*perconf*/
         Arc::new(sender.clone()),
-        sys_sender.clone(),
-        sender.clone(),
+        sys_sender,
+        sender,
     );
 
     let k = kernel(props, cell.clone(), mb, sys).unwrap();
@@ -188,13 +188,13 @@ fn guardian(
 
     let cell = ExtendedCell::new(
         uri.uid,
-        uri.clone(),
+        uri,
         Some(root.clone()),
         sys,
         // None,/*perconf*/
         Arc::new(sender.clone()),
-        sys_sender.clone(),
-        sender.clone(),
+        sys_sender,
+        sender,
     );
 
     let k = kernel(props, cell.clone(), mb, sys).unwrap();
@@ -212,9 +212,7 @@ struct Guardian {
 
 impl Guardian {
     fn new(name: String) -> Self {
-        let actor = Guardian { name };
-
-        actor
+        Guardian { name }
     }
 }
 

--- a/src/kernel/queue.rs
+++ b/src/kernel/queue.rs
@@ -8,10 +8,10 @@ use crate::{Envelope, Message};
 pub fn queue<Msg: Message>() -> (QueueWriter<Msg>, QueueReader<Msg>) {
     let (tx, rx) = channel::<Envelope<Msg>>();
 
-    let qw = QueueWriter { tx: tx };
+    let qw = QueueWriter { tx };
 
     let qr = QueueReaderInner {
-        rx: rx,
+        rx,
         next_item: None,
     };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 
 // #![allow(warnings)] // toggle for easier compile error fixing
 
-#[allow(unused_imports)]
+#![allow(unused_imports)]
 extern crate log;
 
 mod validate;
@@ -35,14 +35,15 @@ pub fn load_config() -> Config {
 
     // load the system config
     // riker.toml contains settings for anything related to the actor framework and its modules
-    let path = env::var("RIKER_CONF").unwrap_or("config/riker.toml".into());
-    cfg.merge(File::with_name(&format!("{}", path)).required(false))
+    let path = env::var("RIKER_CONF")
+        .unwrap_or_else(|_| "config/riker.toml".into());
+    cfg.merge(File::with_name(&path).required(false))
         .unwrap();
 
     // load the user application config
     // app.toml or app.yaml contains settings specific to the user application
-    let path = env::var("APP_CONF").unwrap_or("config/app".into());
-    cfg.merge(File::with_name(&format!("{}", path)).required(false))
+    let path = env::var("APP_CONF").unwrap_or_else(|_| "config/app".into());
+    cfg.merge(File::with_name(&path).required(false))
         .unwrap();
     cfg
 }
@@ -92,7 +93,7 @@ impl AnyMessage {
             }
         } else {
             match self.msg.as_ref() {
-                Some(ref m) if m.is::<T>() => Ok(m.downcast_ref::<T>().map(|t| t.clone()).unwrap()),
+                Some(ref m) if m.is::<T>() => Ok(m.downcast_ref::<T>().cloned().unwrap()),
                 Some(_) => Err(()),
                 None => Err(()),
             }

--- a/src/system/logger.rs
+++ b/src/system/logger.rs
@@ -118,12 +118,12 @@ pub struct LoggerConfig {
 impl<'a> From<&'a Config> for LoggerConfig {
     fn from(config: &Config) -> Self {
         LoggerConfig {
-            time_fmt: config.get_str("log.time_format").unwrap().to_string(),
-            date_fmt: config.get_str("log.date_format").unwrap().to_string(),
-            log_fmt: config.get_str("log.log_format").unwrap().to_string(),
+            time_fmt: config.get_str("log.time_format").unwrap(),
+            date_fmt: config.get_str("log.date_format").unwrap(),
+            log_fmt: config.get_str("log.log_format").unwrap(),
             filter: config
                 .get_array("log.filter")
-                .unwrap_or(vec![])
+                .unwrap_or_else(|_| vec![])
                 .into_iter()
                 .map(|e| e.to_string())
                 .collect(),

--- a/src/system/logger.rs
+++ b/src/system/logger.rs
@@ -79,9 +79,10 @@ impl Drain for DefaultConsoleLogger {
                      record.module(),
                      record.msg());
         }
-        
+
         Ok(())
     }
+}
 
 /// Simple actor that subscribes to the dead letters channel and logs using the default logger
 pub struct DeadLetterLogger {

--- a/src/system/logger.rs
+++ b/src/system/logger.rs
@@ -19,12 +19,12 @@ pub struct LoggerConfig {
 impl<'a> From<&'a Config> for LoggerConfig {
     fn from(config: &Config) -> Self {
         LoggerConfig {
-            time_fmt: config.get_str("log.time_format").unwrap().to_string(),
-            date_fmt: config.get_str("log.date_format").unwrap().to_string(),
-            log_fmt: config.get_str("log.log_format").unwrap().to_string(),
+            time_fmt: config.get_str("log.time_format").unwrap(),
+            date_fmt: config.get_str("log.date_format").unwrap(),
+            log_fmt: config.get_str("log.log_format").unwrap(),
             filter: config
                 .get_array("log.filter")
-                .unwrap_or(vec![])
+                .unwrap_or_default()
                 .into_iter()
                 .map(|e| e.to_string())
                 .collect(),

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -132,10 +132,10 @@ impl fmt::Display for SystemError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             SystemError::ModuleFailed(ref m) => {
-                f.write_str(&format!("{} ({})", self.description(), m))
+                f.write_str(&format!("{} ({})", self.to_string(), m))
             }
             SystemError::InvalidName(ref name) => {
-                f.write_str(&format!("{} ({})", self.description(), name))
+                f.write_str(&format!("{} ({})", self.to_string(), name))
             }
         }
     }
@@ -143,6 +143,6 @@ impl fmt::Display for SystemError {
 
 impl fmt::Debug for SystemError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str(self.description())
+        f.write_str(&self.to_string())
     }
 }

--- a/src/system/system.rs
+++ b/src/system/system.rs
@@ -55,11 +55,12 @@ impl SystemBuilder {
     }
 
     pub fn create(self) -> Result<ActorSystem, SystemError> {
+        let name = self.name.unwrap_or_else(|| "riker".to_string());
         let cfg = self.cfg.unwrap_or_else(load_config);
         let exec = self.exec.unwrap_or_else(|| default_exec(&cfg));
         let log = self.log.unwrap_or_else(|| default_log(&cfg));
 
-        ActorSystem::create(self.name.as_ref().unwrap(), exec, log, cfg)
+        ActorSystem::create(name.as_ref(), exec, log, cfg)
     }
 
     pub fn name(self, name: &str) -> Self {

--- a/src/system/system.rs
+++ b/src/system/system.rs
@@ -14,7 +14,7 @@ use futures::{
     task::{SpawnError, SpawnExt},
     Future,
 };
-use rand;
+
 use uuid::Uuid;
 
 use crate::{

--- a/src/system/system.rs
+++ b/src/system/system.rs
@@ -59,7 +59,7 @@ impl SystemBuilder {
         let exec = self.exec.unwrap_or_else(|| default_exec(&cfg));
         let log = self.log.unwrap_or_else(|| default_log(&cfg));
 
-        ActorSystem::create(&name, exec, log, cfg)
+        ActorSystem::create(self.name.as_ref().unwrap(), exec, log, cfg)
     }
 
     pub fn name(self, name: &str) -> Self {

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -23,13 +23,13 @@ impl Error for InvalidName {
 
 impl fmt::Display for InvalidName {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str(&format!("\"{}\". {}", self.name, self.description()))
+        f.write_str(&format!("\"{}\". {}", self.name, self.to_string()))
     }
 }
 
 impl fmt::Debug for InvalidName {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str(&format!("\"{}\". {}", self.name, self.description()))
+        f.write_str(&format!("\"{}\". {}", self.name, self.to_string()))
     }
 }
 
@@ -54,12 +54,12 @@ impl Error for InvalidPath {
 
 impl fmt::Display for InvalidPath {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str(&format!("\"{}\". {}", self.path, self.description()))
+        f.write_str(&format!("\"{}\". {}", self.path, self.to_string()))
     }
 }
 
 impl fmt::Debug for InvalidPath {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str(&format!("\"{}\". {}", self.path, self.description()))
+        f.write_str(&format!("\"{}\". {}", self.path, self.to_string()))
     }
 }

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -88,7 +88,9 @@ fn system_load_app_config() {
 
 #[test]
 fn system_builder() {
-    let sys = SystemBuilder::new().name("my-sys").create().unwrap();
+    let sys = SystemBuilder::new().create().unwrap();
+    block_on(sys.shutdown()).unwrap();
 
+    let sys = SystemBuilder::new().name("my-sys").create().unwrap();
     block_on(sys.shutdown()).unwrap();
 }


### PR DESCRIPTION
Resolved `cargo clippy` errors and warnings:

```
warning: redundant field names in struct initialization
   --> src/actor/actor_cell.rs:576:13
    |
576 |             interval: interval,
    |             ^^^^^^^^^^^^^^^^^^ help: replace it with: `interval`
    |
    = note: `#[warn(clippy::redundant_field_names)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_field_names

warning: redundant field names in struct initialization
   --> src/actor/actor_cell.rs:578:13
    |
578 |             sender: sender,
    |             ^^^^^^^^^^^^^^ help: replace it with: `sender`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_field_names

warning: redundant field names in struct initialization
   --> src/actor/actor_cell.rs:604:13
    |
604 |             sender: sender,
    |             ^^^^^^^^^^^^^^ help: replace it with: `sender`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_field_names

warning: redundant field names in struct initialization
   --> src/actor/actor_cell.rs:632:13
    |
632 |             sender: sender,
    |             ^^^^^^^^^^^^^^ help: replace it with: `sender`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_field_names

warning: redundant field names in struct initialization
   --> src/kernel/mailbox.rs:376:25
    |
376 |                         sender: sender,
    |                         ^^^^^^^^^^^^^^ help: replace it with: `sender`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_field_names

warning: redundant field names in struct initialization
  --> src/kernel/queue.rs:11:28
   |
11 |     let qw = QueueWriter { tx: tx };
   |                            ^^^^^^ help: replace it with: `tx`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_field_names

warning: redundant field names in struct initialization
  --> src/kernel/queue.rs:14:9
   |
14 |         rx: rx,
   |         ^^^^^^ help: replace it with: `rx`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_field_names

warning: redundant field names in struct initialization
   --> src/system/system.rs:442:13
    |
442 |             interval: interval,
    |             ^^^^^^^^^^^^^^^^^^ help: replace it with: `interval`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_field_names

warning: redundant field names in struct initialization
   --> src/system/system.rs:444:13
    |
444 |             sender: sender,
    |             ^^^^^^^^^^^^^^ help: replace it with: `sender`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_field_names

warning: redundant field names in struct initialization
   --> src/system/system.rs:470:13
    |
470 |             sender: sender,
    |             ^^^^^^^^^^^^^^ help: replace it with: `sender`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_field_names

warning: redundant field names in struct initialization
   --> src/system/system.rs:498:13
    |
498 |             sender: sender,
    |             ^^^^^^^^^^^^^^ help: replace it with: `sender`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_field_names

warning: All variants have the same prefix: `Select`
   --> src/actor/selection.rs:191:1
    |
191 | / enum Selection {
192 | |     SelectParent,
193 | |     SelectChildName(String),
194 | |     SelectAllChildren,
195 | | }
    | |_^
    |
    = note: `#[warn(clippy::enum_variant_names)]` on by default
    = help: remove the prefixes and use full paths to the variants instead of glob imports
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#enum_variant_names

warning: returning the result of a let binding from a block
   --> src/kernel/provider.rs:217:9
    |
215 |         let actor = Guardian { name };
    |         ------------------------------ unnecessary let binding
216 | 
217 |         actor
    |         ^^^^^
    |
    = note: `#[warn(clippy::let_and_return)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#let_and_return
help: return the expression directly
    |
215 |         
216 | 
217 |         Guardian { name }
    |

error: useless lint attribute
 --> src/lib.rs:5:1
  |
5 | #[allow(unused_imports)]
  | ^^^^^^^^^^^^^^^^^^^^^^^^ help: if you just forgot a `!`, use: `#![allow(unused_imports)]`
  |
  = note: `#[deny(clippy::useless_attribute)]` on by default
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_attribute

warning: single-character string constant used as pattern
   --> src/actor/actor_cell.rs:524:54
    |
524 |         let (anchor, path_str) = if path.starts_with("/") {
    |                                                      ^^^ help: try using a char instead: `'/'`
    |
    = note: `#[warn(clippy::single_char_pattern)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_char_pattern

warning: using `clone` on a `Copy` type
   --> src/actor/actor_cell.rs:574:17
    |
574 |             id: id.clone(),
    |                 ^^^^^^^^^^ help: try removing the `clone` call: `id`
    |
    = note: `#[warn(clippy::clone_on_copy)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#clone_on_copy

warning: this let-binding has unit value
   --> src/actor/actor_cell.rs:582:9
    |
582 |         let _ = self.system.timer.send(Job::Repeat(job)).unwrap();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: omit the `let` binding: `self.system.timer.send(Job::Repeat(job)).unwrap();`
    |
    = note: `#[warn(clippy::let_unit_value)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#let_unit_value

warning: using `clone` on a `Copy` type
   --> src/actor/actor_cell.rs:601:17
    |
601 |             id: id.clone(),
    |                 ^^^^^^^^^^ help: try removing the `clone` call: `id`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#clone_on_copy

warning: this let-binding has unit value
   --> src/actor/actor_cell.rs:608:9
    |
608 |         let _ = self.system.timer.send(Job::Once(job)).unwrap();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: omit the `let` binding: `self.system.timer.send(Job::Once(job)).unwrap();`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#let_unit_value

warning: using `clone` on a `Copy` type
   --> src/actor/actor_cell.rs:629:17
    |
629 |             id: id.clone(),
    |                 ^^^^^^^^^^ help: try removing the `clone` call: `id`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#clone_on_copy

warning: this let-binding has unit value
   --> src/actor/actor_cell.rs:636:9
    |
636 |         let _ = self.system.timer.send(Job::Once(job)).unwrap();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: omit the `let` binding: `self.system.timer.send(Job::Once(job)).unwrap();`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#let_unit_value

warning: called `skip(x).next()` on an iterator. This is more succinctly expressed by calling `nth(x)`
   --> src/actor/actor_cell.rs:691:21
    |
691 |         let actor = actors.values().skip(self.position).next();
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(clippy::iter_skip_next)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#iter_skip_next

warning: You are using an explicit closure for cloning elements
   --> src/actor/actor_cell.rs:693:9
    |
693 |         actor.map(|a| a.clone())
    |         ^^^^^^^^^^^^^^^^^^^^^^^^ help: Consider calling the dedicated `cloned` method: `actor.cloned()`
    |
    = note: `#[warn(clippy::map_clone)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#map_clone

warning: you seem to be trying to use match for destructuring a single pattern. Consider using `if let`
  --> src/actor/channel.rs:72:13
   |
72 | /             match evt {
73 | |                 SystemEvent::ActorTerminated(terminated) => {
74 | |                     let subs = self.subs.clone();
75 | |
...  |
80 | |                 _ => {}
81 | |             }
   | |_____________^
   |
   = note: `#[warn(clippy::single_match)]` on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_match
help: try this
   |
72 |             if let SystemEvent::ActorTerminated(terminated) = evt {
73 |     let subs = self.subs.clone();
74 | 
75 |     for topic in subs.keys() {
76 |         unsubscribe(&mut self.subs, topic, &terminated.actor);
77 |     }
 ...

warning: usage of `contains_key` followed by `insert` on a `HashMap`
   --> src/actor/channel.rs:109:9
    |
109 | /         if self.subs.contains_key(&msg.topic) {
110 | |             self.subs.get_mut(&msg.topic).unwrap().push(msg.actor);
111 | |         } else {
112 | |             self.subs.insert(msg.topic, vec![msg.actor]);
113 | |         }
    | |_________^ consider using `self.subs.entry(msg.topic)`
    |
    = note: `#[warn(clippy::map_entry)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#map_entry

error: you are implementing `Hash` explicitly but have derived `PartialEq`
   --> src/actor/channel.rs:340:1
    |
340 | / impl Hash for Topic {
341 | |     fn hash<H: Hasher>(&self, state: &mut H) {
342 | |         self.0.hash(state);
343 | |     }
344 | | }
    | |_^
    |
    = note: `#[deny(clippy::derive_hash_xor_eq)]` on by default
note: `PartialEq` implemented here
   --> src/actor/channel.rs:335:24
    |
335 | #[derive(Clone, Debug, PartialEq)]
    |                        ^^^^^^^^^
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#derive_hash_xor_eq

warning: redundant clone
   --> src/actor/channel.rs:354:20
    |
354 |         Topic(topic.to_string())
    |                    ^^^^^^^^^^^^ help: remove this
    |
    = note: `#[warn(clippy::redundant_clone)]` on by default
note: this value is dropped without further use
   --> src/actor/channel.rs:354:15
    |
354 |         Topic(topic.to_string())
    |               ^^^^^
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_clone

warning: you don't need to add `&` to all patterns
   --> src/actor/channel.rs:360:9
    |
360 | /         match evt {
361 | |             &SystemEvent::ActorCreated(_) => Topic::from("actor.created"),
362 | |             &SystemEvent::ActorTerminated(_) => Topic::from("actor.terminated"),
363 | |             &SystemEvent::ActorRestarted(_) => Topic::from("actor.restarted"),
364 | |         }
    | |_________^
    |
    = note: `#[warn(clippy::match_ref_pats)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#match_ref_pats
help: instead of prefixing all patterns with `&`, you can dereference the expression
    |
360 |         match *evt {
361 |             SystemEvent::ActorCreated(_) => Topic::from("actor.created"),
362 |             SystemEvent::ActorTerminated(_) => Topic::from("actor.terminated"),
363 |             SystemEvent::ActorRestarted(_) => Topic::from("actor.restarted"),
    |

warning: `ref` on an entire `let` pattern is discouraged, take a reference with `&` instead
   --> src/actor/props.rs:216:13
    |
216 |         let ref f = self.creator;
    |         ----^^^^^---------------- help: try: `let f = &self.creator;`
    |
    = note: `#[warn(clippy::toplevel_ref_arg)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#toplevel_ref_arg

warning: `ref` on an entire `let` pattern is discouraged, take a reference with `&` instead
   --> src/actor/props.rs:265:13
    |
265 |         let ref f = self.creator;
    |         ----^^^^^---------------- help: try: `let f = &self.creator;`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#toplevel_ref_arg

warning: writing `&String` instead of `&str` involves a new object where a slice will do.
  --> src/actor/selection.rs:79:19
   |
79 |             path: &String,
   |                   ^^^^^^^ help: change this to: `&str`
   |
   = note: `#[warn(clippy::ptr_arg)]` on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#ptr_arg

warning: You checked before that `unwrap()` cannot fail. Instead of checking and unwrapping, it's better to use `if let` or `match`.
   --> src/actor/selection.rs:103:33
    |
102 |                     if path_vec.peek().is_none() && child.is_some() {
    |                                                     --------------- the check is happening here
103 |                         let _ = child.unwrap().try_tell(msg, sender.clone());
    |                                 ^^^^^^^^^^^^^^
    |
    = note: `#[warn(clippy::unnecessary_unwrap)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_unwrap

warning: writing `&String` instead of `&str` involves a new object where a slice will do.
   --> src/actor/selection.rs:138:19
    |
138 |             path: &String,
    |                   ^^^^^^^ help: change this to: `&str`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#ptr_arg

warning: You checked before that `unwrap()` cannot fail. Instead of checking and unwrapping, it's better to use `if let` or `match`.
   --> src/actor/selection.rs:161:25
    |
160 |                     if path_vec.peek().is_none() && child.is_some() {
    |                                                     --------------- the check is happening here
161 |                         child.unwrap().sys_tell(msg);
    |                         ^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_unwrap

warning: identical conversion
  --> src/kernel/kernel_ref.rs:65:37
   |
65 |         Err(e) => Err(MsgError::new(e.msg.into())),
   |                                     ^^^^^^^^^^^^ help: consider removing `.into()`: `e.msg`
   |
   = note: `#[warn(clippy::identity_conversion)]` on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#identity_conversion

warning: this loop could be written as a `while let` loop
   --> src/kernel/mailbox.rs:267:5
    |
267 | /     loop {
268 | |         match mbox.sys_try_dequeue() {
269 | |             Ok(sys_msg) => {
270 | |                 sys_msgs.push(sys_msg);
...   |
273 | |         }
274 | |     }
    | |_____^ help: try: `while let Ok(sys_msg) = mbox.sys_try_dequeue() { .. }`
    |
    = note: `#[warn(clippy::while_let_loop)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#while_let_loop

warning: this loop could be written as a `while let` loop
   --> src/kernel/mailbox.rs:370:5
    |
370 | /     loop {
371 | |         match mbox.try_dequeue() {
372 | |             Ok(msg) => match (msg.msg, msg.sender) {
373 | |                 (msg, sender) => {
...   |
392 | |         }
393 | |     }
    | |_____^ help: try: `while let Ok(msg) = mbox.try_dequeue() { .. }`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#while_let_loop

warning: redundant clone
  --> src/kernel/provider.rs:65:16
   |
65 |             uri.clone(),
   |                ^^^^^^^^ help: remove this
   |
note: this value is dropped without further use
  --> src/kernel/provider.rs:65:13
   |
65 |             uri.clone(),
   |             ^^^
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_clone

warning: redundant clone
  --> src/kernel/provider.rs:70:23
   |
70 |             sys_sender.clone(),
   |                       ^^^^^^^^ help: remove this
   |
note: this value is dropped without further use
  --> src/kernel/provider.rs:70:13
   |
70 |             sys_sender.clone(),
   |             ^^^^^^^^^^
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_clone

warning: redundant clone
  --> src/kernel/provider.rs:71:19
   |
71 |             sender.clone(),
   |                   ^^^^^^^^ help: remove this
   |
note: this value is dropped without further use
  --> src/kernel/provider.rs:71:13
   |
71 |             sender.clone(),
   |             ^^^^^^
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_clone

warning: redundant clone
   --> src/kernel/provider.rs:156:12
    |
156 |         uri.clone(),
    |            ^^^^^^^^ help: remove this
    |
note: this value is dropped without further use
   --> src/kernel/provider.rs:156:9
    |
156 |         uri.clone(),
    |         ^^^
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_clone

warning: redundant clone
   --> src/kernel/provider.rs:157:21
    |
157 |         Some(bigbang.clone()),
    |                     ^^^^^^^^ help: remove this
    |
note: this value is dropped without further use
   --> src/kernel/provider.rs:157:14
    |
157 |         Some(bigbang.clone()),
    |              ^^^^^^^
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_clone

warning: redundant clone
   --> src/kernel/provider.rs:161:19
    |
161 |         sys_sender.clone(),
    |                   ^^^^^^^^ help: remove this
    |
note: this value is dropped without further use
   --> src/kernel/provider.rs:161:9
    |
161 |         sys_sender.clone(),
    |         ^^^^^^^^^^
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_clone

warning: redundant clone
   --> src/kernel/provider.rs:162:15
    |
162 |         sender.clone(),
    |               ^^^^^^^^ help: remove this
    |
note: this value is dropped without further use
   --> src/kernel/provider.rs:162:9
    |
162 |         sender.clone(),
    |         ^^^^^^
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_clone

warning: redundant clone
   --> src/kernel/provider.rs:191:12
    |
191 |         uri.clone(),
    |            ^^^^^^^^ help: remove this
    |
note: this value is dropped without further use
   --> src/kernel/provider.rs:191:9
    |
191 |         uri.clone(),
    |         ^^^
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_clone

warning: redundant clone
   --> src/kernel/provider.rs:196:19
    |
196 |         sys_sender.clone(),
    |                   ^^^^^^^^ help: remove this
    |
note: this value is dropped without further use
   --> src/kernel/provider.rs:196:9
    |
196 |         sys_sender.clone(),
    |         ^^^^^^^^^^
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_clone

warning: redundant clone
   --> src/kernel/provider.rs:197:15
    |
197 |         sender.clone(),
    |               ^^^^^^^^ help: remove this
    |
note: this value is dropped without further use
   --> src/kernel/provider.rs:197:9
    |
197 |         sender.clone(),
    |         ^^^^^^
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_clone

warning: redundant clone
   --> src/system/logger.rs:121:65
    |
121 |             time_fmt: config.get_str("log.time_format").unwrap().to_string(),
    |                                                                 ^^^^^^^^^^^^ help: remove this
    |
note: this value is dropped without further use
   --> src/system/logger.rs:121:23
    |
121 |             time_fmt: config.get_str("log.time_format").unwrap().to_string(),
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_clone

warning: redundant clone
   --> src/system/logger.rs:122:65
    |
122 |             date_fmt: config.get_str("log.date_format").unwrap().to_string(),
    |                                                                 ^^^^^^^^^^^^ help: remove this
    |
note: this value is dropped without further use
   --> src/system/logger.rs:122:23
    |
122 |             date_fmt: config.get_str("log.date_format").unwrap().to_string(),
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_clone

warning: redundant clone
   --> src/system/logger.rs:123:63
    |
123 |             log_fmt: config.get_str("log.log_format").unwrap().to_string(),
    |                                                               ^^^^^^^^^^^^ help: remove this
    |
note: this value is dropped without further use
   --> src/system/logger.rs:123:22
    |
123 |             log_fmt: config.get_str("log.log_format").unwrap().to_string(),
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_clone

warning: use of `unwrap_or` followed by a function call
   --> src/system/logger.rs:126:18
    |
126 |                 .unwrap_or(vec![])
    |                  ^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|_| vec![])`
    |
    = note: `#[warn(clippy::or_fun_call)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#or_fun_call

warning: you should consider deriving a `Default` implementation for `system::system::SystemBuilder`
  --> src/system/system.rs:53:5
   |
53 | /     pub fn new() -> Self {
54 | |         SystemBuilder {
55 | |             name: None,
56 | |             cfg: None,
...  |
59 | |         }
60 | |     }
   | |_____^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#new_without_default
help: try this
   |
45 | #[derive(Default)]
   |

warning: use of `unwrap_or` followed by a function call
  --> src/system/system.rs:63:28
   |
63 |         let cfg = self.cfg.unwrap_or(load_config());
   |                            ^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(load_config)`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#or_fun_call

warning: use of `unwrap_or` followed by a function call
  --> src/system/system.rs:64:30
   |
64 |         let exec = self.exec.unwrap_or(default_exec(&cfg));
   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|| default_exec(&cfg))`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#or_fun_call

warning: use of `unwrap_or` followed by a function call
  --> src/system/system.rs:65:28
   |
65 |         let log = self.log.unwrap_or(default_log(&cfg));
   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|| default_log(&cfg))`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#or_fun_call

warning: using `clone` on a `Copy` type
   --> src/system/system.rs:233:9
    |
233 |         self.proto.id.clone()
    |         ^^^^^^^^^^^^^^^^^^^^^ help: try removing the `clone` call: `self.proto.id`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#clone_on_copy

warning: single-character string constant used as pattern
   --> src/system/system.rs:373:54
    |
373 |         let (anchor, path_str) = if path.starts_with("/") {
    |                                                      ^^^ help: try using a char instead: `'/'`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_char_pattern

warning: using `clone` on a `Copy` type
   --> src/system/system.rs:440:17
    |
440 |             id: id.clone(),
    |                 ^^^^^^^^^^ help: try removing the `clone` call: `id`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#clone_on_copy

warning: using `clone` on a `Copy` type
   --> src/system/system.rs:467:17
    |
467 |             id: id.clone(),
    |                 ^^^^^^^^^^ help: try removing the `clone` call: `id`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#clone_on_copy

warning: using `clone` on a `Copy` type
   --> src/system/system.rs:495:17
    |
495 |             id: id.clone(),
    |                 ^^^^^^^^^^ help: try removing the `clone` call: `id`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#clone_on_copy

warning: use of `unwrap_or` followed by a function call
  --> src/lib.rs:38:39
   |
38 |     let path = env::var("RIKER_CONF").unwrap_or("config/riker.toml".into());
   |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|_| "config/riker.toml".into())`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#or_fun_call

warning: useless use of `format!`
  --> src/lib.rs:39:32
   |
39 |     cfg.merge(File::with_name(&format!("{}", path)).required(false))
   |                                ^^^^^^^^^^^^^^^^^^^ help: consider using .to_string(): `path.to_string()`
   |
   = note: `#[warn(clippy::useless_format)]` on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_format

warning: use of `unwrap_or` followed by a function call
  --> src/lib.rs:44:37
   |
44 |     let path = env::var("APP_CONF").unwrap_or("config/app".into());
   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|_| "config/app".into())`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#or_fun_call

warning: useless use of `format!`
  --> src/lib.rs:45:32
   |
45 |     cfg.merge(File::with_name(&format!("{}", path)).required(false))
   |                                ^^^^^^^^^^^^^^^^^^^ help: consider using .to_string(): `path.to_string()`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_format

warning: You are using an explicit closure for cloning elements
  --> src/lib.rs:95:50
   |
95 |                 Some(ref m) if m.is::<T>() => Ok(m.downcast_ref::<T>().map(|t| t.clone()).unwrap()),
   |                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: Consider calling the dedicated `cloned` method: `m.downcast_ref::<T>().cloned()`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#map_clone
```

Remaining `cargo clippy` warnings:

```
    Checking riker v0.3.2 (/Users/sergey/Temp/riker)
warning: module has the same name as its containing module
 --> src/actor/mod.rs:1:1
  |
1 | pub(crate) mod actor;
  | ^^^^^^^^^^^^^^^^^^^^^
  |
  = note: `#[warn(clippy::module_inception)]` on by default
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#module_inception

warning: module has the same name as its containing module
 --> src/kernel/mod.rs:1:1
  |
1 | pub(crate) mod kernel;
  | ^^^^^^^^^^^^^^^^^^^^^^
  |
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#module_inception

warning: module has the same name as its containing module
 --> src/system/mod.rs:2:1
  |
2 | pub(crate) mod system;
  | ^^^^^^^^^^^^^^^^^^^^^^
  |
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#module_inception

warning: you should consider deriving a `Default` implementation for `actor::channel::Channel<Msg>`
  --> src/actor/channel.rs:35:5
   |
35 | /     pub fn new() -> Self {
36 | |         Channel {
37 | |             subs: HashMap::new(),
38 | |         }
39 | |     }
   | |_____^
   |
   = note: `#[warn(clippy::new_without_default)]` on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#new_without_default
help: try this
   |
27 | #[derive(Default)]
   |

warning: you should consider adding a `Default` implementation for `actor::channel::EventsChannel`
   --> src/actor/channel.rs:178:5
    |
178 | /     pub fn new() -> Self {
179 | |         EventsChannel(Channel::new())
180 | |     }
    | |_____^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#new_without_default
help: try this
    |
177 | impl Default for actor::channel::EventsChannel {
178 |     fn default() -> Self {
179 |         Self::new()
180 |     }
181 | }
    |

warning: methods called `new` usually return `Self`
  --> src/actor/props.rs:47:5
   |
47 | /     pub fn new<A, F>(creator: F) -> Arc<Mutex<impl ActorProducer<Actor = A>>>
48 | |     where
49 | |         A: Actor + Send + 'static,
50 | |         F: Fn() -> A + Send + 'static,
51 | |     {
52 | |         Arc::new(Mutex::new(ActorProps::new(creator)))
53 | |     }
   | |_____^
   |
   = note: `#[warn(clippy::new_ret_no_self)]` on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#new_ret_no_self

warning: methods called `new` usually return `Self`
   --> src/actor/props.rs:199:5
    |
199 | /     pub fn new<F>(creator: F) -> impl ActorProducer<Actor = A>
200 | |     where
201 | |         F: Fn() -> A + Send + 'static,
202 | |     {
...   |
205 | |         }
206 | |     }
    | |_____^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#new_ret_no_self

warning: methods called `new` usually return `Self`
   --> src/actor/props.rs:246:5
    |
246 | /     pub fn new<F>(creator: F, args: Args) -> impl ActorProducer<Actor = A>
247 | |     where
248 | |         F: Fn(Args) -> A + Send + 'static,
249 | |     {
...   |
253 | |         }
254 | |     }
    | |_____^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#new_ret_no_self

    Finished dev [unoptimized + debuginfo] target(s) in 1.35s
```