### PR TITLE
Thread pool config and defaults

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ pin-utils = "0.1.0-alpha.4"
 slog = "2.5"
 slog-stdlog = "4.0"
 slog-scope = "4.1"
+num_cpus = "1.13.0"
 
 [dev-dependencies]
 riker-testkit = "0.1.0"

--- a/config/riker.toml
+++ b/config/riker.toml
@@ -34,12 +34,12 @@ time_format = "%H:%M:%S%:z"
 
 [mailbox]
 # maximum number of messages to process in each execution of mailbox
-# the mailbox will be rescheduled if there are any remaining messages 
+# the mailbox will be rescheduled if there are any remaining messages
 msg_process_limit = 1000
 
 [dispatcher]
 # number of threads available to the CPU pool
-pool_size = 4
+# pool_size = 4
 
 [scheduler]
 frequency_millis = 50

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,8 @@ pub fn load_config() -> Config {
     cfg.set_default("log.date_format", "%Y-%m-%d").unwrap();
     cfg.set_default("log.time_format", "%H:%M:%S%:z").unwrap();
     cfg.set_default("mailbox.msg_process_limit", 1000).unwrap();
-    cfg.set_default("dispatcher.pool_size", 4).unwrap();
+    cfg.set_default("dispatcher.pool_size", (num_cpus::get() * 2) as i64).unwrap();
+    cfg.set_default("dispatcher.stack_size", 0).unwrap();
     cfg.set_default("scheduler.frequency_millis", 50).unwrap();
 
     // load the system config

--- a/src/system/system.rs
+++ b/src/system/system.rs
@@ -690,12 +690,14 @@ impl<'a> From<&'a Config> for SystemSettings {
 
 struct ThreadPoolConfig {
     pool_size: usize,
+    stack_size: usize,
 }
 
 impl<'a> From<&'a Config> for ThreadPoolConfig {
     fn from(config: &Config) -> Self {
         ThreadPoolConfig {
             pool_size: config.get_int("dispatcher.pool_size").unwrap() as usize,
+            stack_size: config.get_int("dispatcher.stack_size").unwrap() as usize,
         }
     }
 }
@@ -704,6 +706,7 @@ fn default_exec(cfg: &Config) -> ThreadPool {
     let exec_cfg = ThreadPoolConfig::from(cfg);
     ThreadPoolBuilder::new()
         .pool_size(exec_cfg.pool_size)
+        .stack_size(exec_cfg.stack_size)
         .name_prefix("pool-thread-#")
         .create()
         .unwrap()


### PR DESCRIPTION
Changes the default pool_size for the thread_pool to two times the cpu count.

This should give pretty decent default performance without the need to configure something.