### PR TITLE
implement is_empty() and use it according to Clippy's prophecy.

### DIFF
--- a/src/actor/actor_cell.rs
+++ b/src/actor/actor_cell.rs
@@ -111,7 +111,7 @@ impl ActorCell {
     }
 
     pub fn has_children(&self) -> bool {
-        self.inner.children.len() > 0
+        !self.inner.children.is_empty()
     }
 
     pub(crate) fn children<'a>(&'a self) -> Box<dyn Iterator<Item = BasicActorRef> + 'a> {
@@ -722,6 +722,10 @@ impl Children {
 
     pub fn len(&self) -> usize {
         self.actors.read().unwrap().len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.actors.read().unwrap().is_empty()
     }
 
     pub fn iter(&self) -> ChildrenIterator {


### PR DESCRIPTION
Clippy complains that we have a `.len()` method, but no corresponding `.is_empty()` method.
Once implemented, it then recommends using `!is_empty()` in place of `len() > 0`.