### PR TITLE
#107 Set newline style in .gitattributes and change newline_style in rustfmt.toml

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,5 +1,5 @@
 hard_tabs = false
 tab_spaces = 4
-newline_style = "Unix"
+newline_style = "Native"
 max_width = 100
 edition = "2018"


### PR DESCRIPTION
This fixes #107 by always using native newlines on the users machine, but converting to LF when commiting.