### PR TITLE
Simplify provider::register()

### DIFF
--- a/src/kernel/provider.rs
+++ b/src/kernel/provider.rs
@@ -87,17 +87,12 @@ impl Provider {
     }
 
     fn register(&self, path: &ActorPath) -> Result<ActorId, CreateError> {
-        if self.inner.paths.contains_key(path) {
+        let old = self.inner.paths.replace(path.clone(), ());
+        if let Some(_) = old {
             Err(CreateError::AlreadyExists(path.clone()))
         } else {
-            let old = self.inner.paths.replace(path.clone(), ());
-            if let Some(old) = old {
-                self.inner.paths.replace(old.key().clone(), ());
-                Err(CreateError::AlreadyExists(path.clone()))
-            } else {
-                let id = self.inner.counter.fetch_add(1, Ordering::SeqCst);
-                Ok(id)
-            }
+            let id = self.inner.counter.fetch_add(1, Ordering::SeqCst);
+            Ok(id)
         }
     }
 

--- a/src/kernel/provider.rs
+++ b/src/kernel/provider.rs
@@ -88,7 +88,7 @@ impl Provider {
 
     fn register(&self, path: &ActorPath) -> Result<ActorId, CreateError> {
         let old = self.inner.paths.replace(path.clone(), ());
-        if let Some(_) = old {
+        if old.is_some() {
             Err(CreateError::AlreadyExists(path.clone()))
         } else {
             let id = self.inner.counter.fetch_add(1, Ordering::SeqCst);


### PR DESCRIPTION
Currently the register method checks if a path is already in the dashmap. If it is, it calls replace which returns the old value if one was present. If the old value was present, it replaces the old value again.

Because the value is always `()` and replace already handles the case where a path is already registered, this method can be simplified which should make reasoning about the code easier.
This should also make it a bit faster, because it removes duplicate calls to replace and one one unnecessary call to contains_key.