### PR TITLE
Remove actor id

### DIFF
--- a/src/actor.rs
+++ b/src/actor.rs
@@ -25,7 +25,7 @@ pub use self::{
     macros::actor,
     props::{ActorArgs, ActorFactory, ActorFactoryArgs, ActorProducer, BoxActorProd, Props},
     selection::{ActorSelection, ActorSelectionFactory},
-    uri::{ActorId, ActorPath, ActorUri, AtomicActorId},
+    uri::{ActorPath, ActorUri},
 };
 
 use crate::{system::SystemMsg, Message};

--- a/src/actor/actor_cell.rs
+++ b/src/actor/actor_cell.rs
@@ -34,7 +34,6 @@ pub struct ActorCell {
 
 #[derive(Clone)]
 struct ActorCellInner {
-    uid: ActorId,
     uri: ActorUri,
     parent: Option<BasicActorRef>,
     children: Children,
@@ -51,7 +50,6 @@ struct ActorCellInner {
 impl ActorCell {
     /// Constructs a new `ActorCell`
     pub(crate) fn new(
-        uid: ActorId,
         uri: ActorUri,
         parent: Option<BasicActorRef>,
         system: &ActorSystem,
@@ -60,7 +58,6 @@ impl ActorCell {
     ) -> ActorCell {
         ActorCell {
             inner: Arc::new(ActorCellInner {
-                uid,
                 uri,
                 parent,
                 children: Children::new(),
@@ -116,7 +113,7 @@ impl ActorCell {
     }
 
     pub(crate) fn is_root(&self) -> bool {
-        self.inner.uid == 0
+        self.myself().path() == "/"
     }
 
     pub fn is_user(&self) -> bool {
@@ -298,7 +295,6 @@ where
     Msg: Message,
 {
     pub(crate) fn new(
-        uid: ActorId,
         uri: ActorUri,
         parent: Option<BasicActorRef>,
         system: &ActorSystem,
@@ -308,7 +304,6 @@ where
     ) -> Self {
         let cell = ActorCell {
             inner: Arc::new(ActorCellInner {
-                uid,
                 uri,
                 parent,
                 children: Children::new(),

--- a/src/actor/uri.rs
+++ b/src/actor/uri.rs
@@ -1,11 +1,9 @@
 use std::{
     fmt,
     hash::{Hash, Hasher},
-    sync::{atomic::AtomicUsize, Arc},
+    sync::Arc,
 };
 
-pub type AtomicActorId = AtomicUsize;
-pub type ActorId = usize;
 pub struct ActorPath(Arc<String>);
 
 impl ActorPath {
@@ -59,7 +57,6 @@ impl Clone for ActorPath {
 /// networking and clustering are introduced.
 #[derive(Clone)]
 pub struct ActorUri {
-    pub uid: ActorId,
     pub name: Arc<String>,
     pub path: ActorPath,
     pub host: Arc<String>,
@@ -87,6 +84,6 @@ impl fmt::Display for ActorUri {
 
 impl fmt::Debug for ActorUri {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}://{}#{}", self.host, self.path, self.uid)
+        write!(f, "{}://{}", self.host, self.path)
     }
 }

--- a/src/kernel/provider.rs
+++ b/src/kernel/provider.rs
@@ -162,12 +162,7 @@ fn root(sys: &ActorSystem) -> BasicActorRef {
     BasicActorRef::from(actor_ref)
 }
 
-fn guardian(
-    name: &str,
-    path: &str,
-    root: &BasicActorRef,
-    sys: &ActorSystem,
-) -> BasicActorRef {
+fn guardian(name: &str, path: &str, root: &BasicActorRef, sys: &ActorSystem) -> BasicActorRef {
     let uri = ActorUri {
         name: Arc::new(name.to_string()),
         path: ActorPath::new(path),

--- a/src/kernel/provider.rs
+++ b/src/kernel/provider.rs
@@ -1,7 +1,7 @@
 use dashmap::DashMap;
 use slog::trace;
 
-use std::sync::{atomic::Ordering, Arc};
+use std::sync::Arc;
 
 use crate::system::LoggingSystem;
 use crate::{
@@ -20,15 +20,12 @@ pub struct Provider {
 }
 
 struct ProviderInner {
-    counter: AtomicActorId,
     paths: DashMap<ActorPath, ()>,
 }
 
 impl Provider {
     pub fn new(log: LoggingSystem) -> Self {
         let inner = ProviderInner {
-            // ActorIds start at 100
-            counter: AtomicActorId::new(100),
             paths: DashMap::new(),
         };
 
@@ -53,10 +50,9 @@ impl Provider {
         let path = ActorPath::new(&format!("{}/{}", parent.path(), name));
         trace!(sys.log(), "Attempting to create actor at: {}", path);
 
-        let uid = self.register(&path)?;
+        self.register(&path)?;
 
         let uri = ActorUri {
-            uid,
             path,
             name: Arc::new(name.into()),
             host: sys.host(),
@@ -65,7 +61,6 @@ impl Provider {
         let (sender, sys_sender, mb) = mailbox::<A::Msg>(sys.sys_settings().msg_process_limit);
 
         let cell = ExtendedCell::new(
-            uri.uid,
             uri,
             Some(parent.clone()),
             sys,
@@ -86,7 +81,7 @@ impl Provider {
         Ok(actor)
     }
 
-    fn register(&self, path: &ActorPath) -> Result<ActorId, CreateError> {
+    fn register(&self, path: &ActorPath) -> Result<(), CreateError> {
         if self.inner.paths.contains_key(path) {
             Err(CreateError::AlreadyExists(path.clone()))
         } else {
@@ -95,8 +90,8 @@ impl Provider {
                 self.inner.paths.replace(old.key().clone(), ());
                 Err(CreateError::AlreadyExists(path.clone()))
             } else {
-                let id = self.inner.counter.fetch_add(1, Ordering::SeqCst);
-                Ok(id)
+                // let id = self.inner.counter.fetch_add(1, Ordering::SeqCst);
+                Ok(())
             }
         }
     }
@@ -110,16 +105,15 @@ pub fn create_root(sys: &ActorSystem) -> SysActors {
     let root = root(sys);
 
     SysActors {
-        user: guardian(1, "user", "/user", &root, sys),
-        sysm: guardian(2, "system", "/system", &root, sys),
-        temp: guardian(3, "temp", "/temp", &root, sys),
+        user: guardian("user", "/user", &root, sys),
+        sysm: guardian("system", "/system", &root, sys),
+        temp: guardian("temp", "/temp", &root, sys),
         root,
     }
 }
 
 fn root(sys: &ActorSystem) -> BasicActorRef {
     let uri = ActorUri {
-        uid: 0,
         name: Arc::new("root".to_string()),
         path: ActorPath::new("/"),
         host: Arc::new("localhost".to_string()),
@@ -137,7 +131,6 @@ fn root(sys: &ActorSystem) -> BasicActorRef {
     // };
 
     let bb_cell = ActorCell::new(
-        0,
         uri.clone(),
         None,
         sys,
@@ -154,7 +147,6 @@ fn root(sys: &ActorSystem) -> BasicActorRef {
     let (sender, sys_sender, mb) = mailbox::<SystemMsg>(100);
 
     let cell = ExtendedCell::new(
-        uri.uid,
         uri,
         Some(bigbang),
         sys,
@@ -172,14 +164,12 @@ fn root(sys: &ActorSystem) -> BasicActorRef {
 }
 
 fn guardian(
-    uid: ActorId,
     name: &str,
     path: &str,
     root: &BasicActorRef,
     sys: &ActorSystem,
 ) -> BasicActorRef {
     let uri = ActorUri {
-        uid,
         name: Arc::new(name.to_string()),
         path: ActorPath::new(path),
         host: Arc::new("localhost".to_string()),
@@ -190,7 +180,6 @@ fn guardian(
     let (sender, sys_sender, mb) = mailbox::<SystemMsg>(100);
 
     let cell = ExtendedCell::new(
-        uri.uid,
         uri,
         Some(root.clone()),
         sys,

--- a/src/kernel/provider.rs
+++ b/src/kernel/provider.rs
@@ -90,7 +90,6 @@ impl Provider {
                 self.inner.paths.replace(old.key().clone(), ());
                 Err(CreateError::AlreadyExists(path.clone()))
             } else {
-                // let id = self.inner.counter.fetch_add(1, Ordering::SeqCst);
                 Ok(())
             }
         }


### PR DESCRIPTION
Removes the actor ID because it isn't used anywhere except to check if an actor is the root. Also if riker is used on systems where usize is 32 bit or smaller, there is a chance that the actor id wraps around and multiple actors could end up with the same id.

The old is_root checks if the actor id is 0. In case of an overflow this could happen more than once.

The new is_root function uses the actor path, because it is already guaranteed that there can't be a second actor with the same path.