### PR TITLE
Switch to syn, quote, proc-macro2 version 1.0

### DIFF
--- a/riker-macros/Cargo.toml
+++ b/riker-macros/Cargo.toml
@@ -14,9 +14,9 @@ keywords = ["actors", "actor-model", "async", "cqrs", "event_sourcing"]
 proc-macro = true
 
 [dependencies]
-syn = { version ="0.15.39", features = ["parsing", "full", "extra-traits", "proc-macro"] }
-quote = "0.6.3"
-proc-macro2 = "0.4.4"
+syn = { version ="1.0", features = ["parsing", "full", "extra-traits", "proc-macro"] }
+quote = "1.0"
+proc-macro2 = "1.0"
 
 [dev-dependencies]
 riker = { path = ".." }


### PR DESCRIPTION
There don't seem to be any incompatible changes, this brings it to the same version used by most other crates