### PR TITLE
Changed Cargo.toml version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Riker provides:
 
 ```toml
 [dependencies]
-riker = "0.3.1"
+riker = "0.4.1"
 ```
 
 `main.rs`:


### PR DESCRIPTION
I just tried riker for the first time, and couldn't get the example in the readme to compile. Then I noticed the Cargo.toml version was wrong, so I changed it. The example compiles now.