### PR TITLE
fix(dashmap): use stable dashmap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,8 @@ slog = "2.5"
 slog-stdlog = "4.0"
 slog-scope = "4.3.0"
 num_cpus = "1.13.0"
-dashmap = "4.0.0-rc5"
+dashmap = "3"
+
 
 [dev-dependencies]
 riker-testkit = "0.1.0"

--- a/riker-macros/Cargo.toml
+++ b/riker-macros/Cargo.toml
@@ -14,9 +14,9 @@ keywords = ["actors", "actor-model", "async", "cqrs", "event_sourcing"]
 proc-macro = true
 
 [dependencies]
-syn = { version ="1.0", features = ["parsing", "full", "extra-traits", "proc-macro"] }
-quote = "1.0"
-proc-macro2 = "1.0"
+syn = { version ="0.15.39", features = ["parsing", "full", "extra-traits", "proc-macro"] }
+quote = "0.6.3"
+proc-macro2 = "0.4.4"
 
 [dev-dependencies]
 riker = { path = ".." }

--- a/riker-macros/Cargo.toml
+++ b/riker-macros/Cargo.toml
@@ -14,9 +14,9 @@ keywords = ["actors", "actor-model", "async", "cqrs", "event_sourcing"]
 proc-macro = true
 
 [dependencies]
-syn = { version ="0.15.39", features = ["parsing", "full", "extra-traits", "proc-macro"] }
-quote = "0.6.3"
-proc-macro2 = "0.4.4"
+syn = { version ="1.0", features = ["parsing", "full", "extra-traits", "proc-macro"] }
+quote = "1.0"
+proc-macro2 = "1.0"
 
 [dev-dependencies]
 riker = { path = ".." }

--- a/src/actor/actor_cell.rs
+++ b/src/actor/actor_cell.rs
@@ -1,6 +1,7 @@
 use std::{
     fmt,
     ops::Deref,
+    rc::Rc,
     sync::{
         atomic::{AtomicBool, AtomicUsize, Ordering},
         Arc,
@@ -9,7 +10,7 @@ use std::{
 };
 
 use chrono::prelude::*;
-use dashmap::{DashMap, Iter};
+use dashmap::{DashMap, iter::Iter};
 use futures::{future::RemoteHandle, task::SpawnError, Future};
 use uuid::Uuid;
 
@@ -650,21 +651,7 @@ impl Children {
         self.actors.len()
     }
 
-    pub fn iter(&self) -> ChildrenIterator {
-        ChildrenIterator {
-            children: self.actors.iter(),
-        }
-    }
-}
-
-pub struct ChildrenIterator {
-    children: Iter<String, BasicActorRef>,
-}
-
-impl Iterator for ChildrenIterator {
-    type Item = BasicActorRef;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.children.next().map(|e| e.value().clone())
+    pub fn iter(&self) -> impl Iterator<Item = BasicActorRef> + '_ {
+        self.actors.iter().map(|e| e.value().clone())
     }
 }

--- a/src/actor/actor_cell.rs
+++ b/src/actor/actor_cell.rs
@@ -1,7 +1,6 @@
 use std::{
     fmt,
     ops::Deref,
-    rc::Rc,
     sync::{
         atomic::{AtomicBool, AtomicUsize, Ordering},
         Arc,
@@ -10,7 +9,7 @@ use std::{
 };
 
 use chrono::prelude::*;
-use dashmap::{DashMap, iter::Iter};
+use dashmap::{DashMap};
 use futures::{future::RemoteHandle, task::SpawnError, Future};
 use uuid::Uuid;
 

--- a/src/actor/actor_cell.rs
+++ b/src/actor/actor_cell.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use chrono::prelude::*;
-use dashmap::{DashMap};
+use dashmap::DashMap;
 use futures::{future::RemoteHandle, task::SpawnError, Future};
 use uuid::Uuid;
 

--- a/src/kernel/provider.rs
+++ b/src/kernel/provider.rs
@@ -82,7 +82,7 @@ impl Provider {
     }
 
     fn register(&self, path: &ActorPath) -> Result<(), CreateError> {
-        let old = self.inner.paths.replace(path.clone(), ());
+        let old = self.inner.paths.insert(path.clone(), ());
         if old.is_some() {
             Err(CreateError::AlreadyExists(path.clone()))
         } else {


### PR DESCRIPTION
This is basically the same as pr #132, just resolved the conflict. I ran pre-commit, all tests pass, all examples seem to work fine and no warnings are thrown on build. I tested it integrated in a project that works with the current release version, and this change continues to work properly and as expected (on macOS). I did remove a couple of the changes proposed by @bfrog because there is apparently no longer any need for the Dashmap iterator and no reason to submit code that has warnings. ;)

I guess it would probably be good to add a test to check this deadlock issue though, but I am not sure how to replicate that.

Closes #131  
Closes #122

![image](https://user-images.githubusercontent.com/35242872/100081557-7414ad80-2e47-11eb-800e-c238e5153dbb.png)