### PR TITLE
fix clippy::to_string_in_display issues

### DIFF
--- a/src/actor.rs
+++ b/src/actor.rs
@@ -7,7 +7,7 @@ pub(crate) mod props;
 pub(crate) mod selection;
 pub(crate) mod uri;
 
-use std::{error::Error, fmt};
+use std::fmt;
 
 use crate::validate::InvalidName;
 
@@ -46,15 +46,9 @@ impl<T> MsgError<T> {
     }
 }
 
-impl<T> Error for MsgError<T> {
-    fn description(&self) -> &str {
-        "The actor does not exist. It may have been terminated"
-    }
-}
-
 impl<T> fmt::Display for MsgError<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str(&self.to_string())
+        f.write_str("The actor does not exist. It may have been terminated")
     }
 }
 
@@ -75,15 +69,9 @@ impl<T> TryMsgError<T> {
     }
 }
 
-impl<T> Error for TryMsgError<T> {
-    fn description(&self) -> &str {
-        "Option<ActorRef> is None"
-    }
-}
-
 impl<T> fmt::Display for TryMsgError<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str(&self.to_string())
+        f.write_str("Option<ActorRef> is None")
     }
 }
 
@@ -102,22 +90,22 @@ pub enum CreateError {
     AlreadyExists(ActorPath),
 }
 
-impl Error for CreateError {
-    fn description(&self) -> &str {
-        match *self {
-            CreateError::Panicked => "Failed to create actor. Cause: Actor panicked while starting",
-            CreateError::System => "Failed to create actor. Cause: System failure",
-            CreateError::InvalidName(_) => "Failed to create actor. Cause: Invalid actor name",
-            CreateError::AlreadyExists(_) => {
-                "Failed to create actor. Cause: An actor at the same path already exists"
-            }
-        }
-    }
-}
-
 impl fmt::Display for CreateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Debug::fmt(self, f)
+        match *self {
+            Self::Panicked => {
+                f.write_str("Failed to create actor. Cause: Actor panicked while starting")
+            }
+            Self::System => f.write_str("Failed to create actor. Cause: System failure"),
+            Self::InvalidName(ref name) => f.write_str(&format!(
+                "Failed to create actor. Cause: Invalid actor name ({})",
+                name
+            )),
+            Self::AlreadyExists(ref path) => f.write_str(&format!(
+                "Failed to create actor. Cause: An actor at the same path already exists ({})",
+                path
+            )),
+        }
     }
 }
 
@@ -130,15 +118,9 @@ impl From<InvalidName> for CreateError {
 /// Error type when an actor fails to restart.
 pub struct RestartError;
 
-impl Error for RestartError {
-    fn description(&self) -> &str {
-        "Failed to restart actor. Cause: Actor panicked while starting"
-    }
-}
-
 impl fmt::Display for RestartError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str(&self.to_string())
+        f.write_str("Failed to restart actor. Cause: Actor panicked while starting")
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,6 @@
 // #![deny(clippy::nursery)]
 #![allow(clippy::new_ret_no_self)]
 #![allow(clippy::large_enum_variant)]
-#![allow(clippy::to_string_in_display)]
 
 mod validate;
 

--- a/src/system.rs
+++ b/src/system.rs
@@ -1,7 +1,7 @@
 pub(crate) mod logger;
 pub(crate) mod timer;
 
-use std::{error::Error, fmt};
+use std::fmt;
 
 use crate::actor::BasicActorRef;
 
@@ -111,28 +111,17 @@ pub enum SystemError {
     InvalidName(String),
 }
 
-impl Error for SystemError {
-    fn description(&self) -> &str {
-        match *self {
-            SystemError::ModuleFailed(_) => {
-                "Failed to create actor system. Cause: Sub module failed to start"
-            }
-            SystemError::InvalidName(_) => {
-                "Failed to create actor system. Cause: Invalid actor system name"
-            }
-        }
-    }
-}
-
 impl fmt::Display for SystemError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            SystemError::ModuleFailed(ref m) => {
-                f.write_str(&format!("{} ({})", self.to_string(), m))
-            }
-            SystemError::InvalidName(ref name) => {
-                f.write_str(&format!("{} ({})", self.to_string(), name))
-            }
+            SystemError::ModuleFailed(ref m) => f.write_str(&format!(
+                "Failed to create actor system. Cause: Sub module failed to start ({})",
+                m
+            )),
+            SystemError::InvalidName(ref name) => f.write_str(&format!(
+                "Failed to create actor system. Cause: Invalid actor system name ({})",
+                name
+            )),
         }
     }
 }

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -1,5 +1,4 @@
 use regex::Regex;
-use std::error::Error;
 use std::fmt;
 
 pub fn validate_name(name: &str) -> Result<(), InvalidName> {
@@ -15,21 +14,18 @@ pub struct InvalidName {
     pub name: String,
 }
 
-impl Error for InvalidName {
-    fn description(&self) -> &str {
-        "Invalid name. Must contain only a-Z, 0-9, _, or -"
-    }
-}
-
 impl fmt::Display for InvalidName {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str(&format!("\"{}\". {}", self.name, self.to_string()))
+        f.write_str(&format!(
+            "\"{}\". Invalid name. Must contain only a-Z, 0-9, _, or -",
+            self.name
+        ))
     }
 }
 
 impl fmt::Debug for InvalidName {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str(&format!("\"{}\". {}", self.name, self.to_string()))
+        f.write_str(&self.to_string())
     }
 }
 
@@ -46,20 +42,17 @@ pub struct InvalidPath {
     path: String,
 }
 
-impl Error for InvalidPath {
-    fn description(&self) -> &str {
-        "Invalid path. Must contain only a-Z, 0-9, /, _, .., - or *"
-    }
-}
-
 impl fmt::Display for InvalidPath {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str(&format!("\"{}\". {}", self.path, self.to_string()))
+        f.write_str(&format!(
+            "\"{}\". Invalid path. Must contain only a-Z, 0-9, /, _, .., - or *",
+            self.path
+        ))
     }
 }
 
 impl fmt::Debug for InvalidPath {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str(&format!("\"{}\". {}", self.path, self.to_string()))
+        f.write_str(&self.to_string())
     }
 }

--- a/tests/actors.rs
+++ b/tests/actors.rs
@@ -53,7 +53,23 @@ fn actor_create() {
 
     assert!(sys.actor_of::<Counter>("valid-name").is_ok());
 
-    assert!(sys.actor_of::<Counter>("/").is_err());
+    match sys.actor_of::<Counter>("/") {
+        Ok(_) => panic!("test should not reach here"),
+        Err(e) => {
+            // test Display
+            assert_eq!(
+                e.to_string(),
+                "Failed to create actor. Cause: Invalid actor name (/)"
+            );
+            assert_eq!(
+                format!("{}", e),
+                "Failed to create actor. Cause: Invalid actor name (/)"
+            );
+            // test Debug
+            assert_eq!(format!("{:?}", e), "InvalidName(\"/\")");
+            assert_eq!(format!("{:#?}", e), "InvalidName(\n    \"/\",\n)");
+        }
+    }
     assert!(sys.actor_of::<Counter>("*").is_err());
     assert!(sys.actor_of::<Counter>("/a/b/c").is_err());
     assert!(sys.actor_of::<Counter>("@").is_err());


### PR DESCRIPTION
according to https://doc.rust-lang.org/std/error/trait.Error.html#method.description
Error description function is "Deprecated since 1.42.0: use the Display impl or to_string()"