### PR TITLE
Use feature flag to enable wasm builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ config = "0.10.1"
 futures = { version = "0.3.4", features = ["thread-pool"] }
 rand = "0.7"
 regex = "1"
-uuid = { version = "0.8.1", features = ["v4"] }
+uuid = { package = "uuid", version = "0.8.1", features = ["v4"] }
 pin-utils = "0.1.0"
 slog = "2.5"
 slog-stdlog = "4.0"
@@ -32,3 +32,7 @@ dashmap = "3"
 [dev-dependencies]
 riker-testkit = "0.1.0"
 log = "0.4"
+
+[features]
+default = []
+wasm = ["uuid/wasm-bindgen"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ config = "0.10.1"
 futures = { version = "0.3.4", features = ["thread-pool"] }
 rand = "0.7"
 regex = "1"
-uuid = { package = "uuid", version = "0.8.1", features = ["v4"] }
+uuid = { version = "0.8.1", features = ["v4"] }
 pin-utils = "0.1.0"
 slog = "2.5"
 slog-stdlog = "4.0"

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Riker provides:
 - Out-of-the-box, configurable, non-blocking logging
 - Command Query Responsibility Segregation (CQRS)
 - Easily run futures
+- Can be used with wasm (Just set `wasm` feature flag)
 
 [Website](https://riker.rs) | [API Docs](https://docs.rs/riker)
 


### PR DESCRIPTION
Closes #151.

This just adds a feature flag (and relevant uuid feature) that allows devs to conditionally compile riker for wasm runtimes.