### PR TITLE
implement From<#ty> for actor message enum

### DIFF
--- a/riker-macros/src/lib.rs
+++ b/riker-macros/src/lib.rs
@@ -103,7 +103,7 @@ fn intos(name: &Ident, types: &MsgTypes) -> TokenStream {
     let intos = types
         .types
         .iter()
-        .map(|t| impl_into(&name, &t.name, &t.mtype));
+        .map(|t| impl_from(&name, &t.name, &t.mtype));
     quote! {
         #(#intos)*
     }
@@ -135,11 +135,11 @@ fn receive(aname: &Ident, gen: &Generics, name: &Ident, types: &MsgTypes) -> Tok
     }
 }
 
-fn impl_into(name: &Ident, vname: &Ident, ty: &TypePath) -> TokenStream {
+fn impl_from(name: &Ident, vname: &Ident, ty: &TypePath) -> TokenStream {
     quote! {
-        impl Into<#name> for #ty {
-            fn into(self) -> #name {
-                #name::#vname(self)
+        impl From<#ty> for #name {
+            fn from(t: #ty) -> Self {
+                #name::#vname(t)
             }
         }
     }


### PR DESCRIPTION
Issue #161 
Implement From<#ty> for the actor message enum in the actor macro.
Enables constructing the actor message enum (`ActorMsg`) of an actor from the specific message types.