### PR TITLE
Updating the example code in the readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ impl Actor for MyActor {
 fn main() {
     let sys = ActorSystem::new().unwrap();
 
-    let my_actor = sys.actor_of::<MyActor>("my-actor").unwrap();
+    let my_actor = sys.sys_actor_of::<MyActor>("my-actor").unwrap();
 
     my_actor.tell("Hello my actor!".to_string(), None);
 


### PR DESCRIPTION
I think `actor_of` was replaced with `sys_actor_of` ? On `riker = "0.4.2"` I get an error that the example function does not exist, but checking source I see this one is public.