### PR TITLE
Use From instead of Into traits in actor macro

### DIFF
--- a/riker-macros/src/lib.rs
+++ b/riker-macros/src/lib.rs
@@ -103,7 +103,9 @@ fn intos(name: &Ident, types: &MsgTypes) -> TokenStream {
     let intos = types
         .types
         .iter()
-        .map(|t| impl_into(&name, &t.name, &t.mtype));
+        .map(|t| {
+            impl_from(&name, &t.name, &t.mtype)
+        });
     quote! {
         #(#intos)*
     }
@@ -135,11 +137,11 @@ fn receive(aname: &Ident, gen: &Generics, name: &Ident, types: &MsgTypes) -> Tok
     }
 }
 
-fn impl_into(name: &Ident, vname: &Ident, ty: &TypePath) -> TokenStream {
+fn impl_from(name: &Ident, vname: &Ident, ty: &TypePath) -> TokenStream {
     quote! {
-        impl Into<#name> for #ty {
-            fn into(self) -> #name {
-                #name::#vname(self)
+        impl From<#ty> for #name {
+            fn from(msg: #ty) -> #name {
+                #name::#vname(msg)
             }
         }
     }


### PR DESCRIPTION
Context: 

In some cases I need to decouple the actors, where they only need to send messages using the reference of the actor to whom I am going to send messages.

Example:

```
#[actor(String, u32, NotifyMessage)]
struct ActorA { ... }

enum NotifyMessage {
  Notify
}

struct ActorB<M>
where M: Message + From<NotifyMessage>
{
  link: ActorRef<M>
}
impl Actor for ActorB<M>
where M: Message + From<NotifyMessage> {
...
}

impl<M> Receive<String> for ActorB<M>
where
    M: Message + From<NotifyMessage>,
{
    type Msg = String;

    fn receive(&mut self, ctx: &Context<Self::Msg>, msg: Internal, sender: Sender) {
          self.link.tell(M::from(SomeActions::Notify), None);
    }
}

...
    let act_b = sys
        .actor_of_args::<ActorB<ActorAMsg>, _>("actor-b", act_a.clone())
        .unwrap();
```