### PR TITLE
Updated deps to get rid of future-incompatible warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,17 +16,17 @@ travis-ci = { repository = "riker-rs/riker" }
 [dependencies]
 riker-macros = { path = "riker-macros", version = "0.2.0" }
 chrono = "0.4"
-config = "0.10.1"
+config = "0.13.3"
 futures = { version = "0.3.4", features = ["thread-pool"] }
-rand = "0.7"
+rand = "0.8"
 regex = "1"
-uuid = { version = "0.8.1", features = ["v4"] }
+uuid = { version = "1.1.2", features = ["v4"] }
 pin-utils = "0.1.0"
 slog = "2.5"
 slog-stdlog = "4.0"
 slog-scope = "4.3.0"
 num_cpus = "1.13.0"
-dashmap = "3"
+dashmap = "5"
 
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,30 +21,37 @@ use config::{Config, File};
 use crate::actor::BasicActorRef;
 
 pub fn load_config() -> Config {
-    let mut cfg = Config::new();
-
-    cfg.set_default("debug", true).unwrap();
-    cfg.set_default("log.level", "debug").unwrap();
-    cfg.set_default("log.log_format", "{date} {time} {level} [{module}] {body}")
-        .unwrap();
-    cfg.set_default("log.date_format", "%Y-%m-%d").unwrap();
-    cfg.set_default("log.time_format", "%H:%M:%S%:z").unwrap();
-    cfg.set_default("mailbox.msg_process_limit", 1000).unwrap();
-    cfg.set_default("dispatcher.pool_size", (num_cpus::get() * 2) as i64)
-        .unwrap();
-    cfg.set_default("dispatcher.stack_size", 0).unwrap();
-    cfg.set_default("scheduler.frequency_millis", 50).unwrap();
-
     // load the system config
     // riker.toml contains settings for anything related to the actor framework and its modules
-    let path = env::var("RIKER_CONF").unwrap_or_else(|_| "config/riker.toml".into());
-    cfg.merge(File::with_name(&path).required(false)).unwrap();
+    let riker_conf_path = env::var("RIKER_CONF").unwrap_or_else(|_| "config/riker.toml".into());
 
     // load the user application config
     // app.toml or app.yaml contains settings specific to the user application
-    let path = env::var("APP_CONF").unwrap_or_else(|_| "config/app".into());
-    cfg.merge(File::with_name(&path).required(false)).unwrap();
-    cfg
+    let app_conf_path = env::var("APP_CONF").unwrap_or_else(|_| "config/app".into());
+
+    let cfg = Config::builder();
+    cfg.set_default("debug", true)
+        .unwrap()
+        .set_default("log.level", "debug")
+        .unwrap()
+        .set_default("log.log_format", "{date} {time} {level} [{module}] {body}")
+        .unwrap()
+        .set_default("log.date_format", "%Y-%m-%d")
+        .unwrap()
+        .set_default("log.time_format", "%H:%M:%S%:z")
+        .unwrap()
+        .set_default("mailbox.msg_process_limit", 1000)
+        .unwrap()
+        .set_default("dispatcher.pool_size", (num_cpus::get() * 2) as i64)
+        .unwrap()
+        .set_default("dispatcher.stack_size", 0)
+        .unwrap()
+        .set_default("scheduler.frequency_millis", 50)
+        .unwrap()
+        .add_source(File::with_name(&riker_conf_path).required(false))
+        .add_source(File::with_name(&app_conf_path).required(false))
+        .build()
+        .unwrap()
 }
 
 /// Wraps message and sender

--- a/src/system/logger.rs
+++ b/src/system/logger.rs
@@ -22,9 +22,9 @@ pub struct LoggerConfig {
 impl<'a> From<&'a Config> for LoggerConfig {
     fn from(config: &Config) -> Self {
         LoggerConfig {
-            time_fmt: config.get_str("log.time_format").unwrap(),
-            date_fmt: config.get_str("log.date_format").unwrap(),
-            log_fmt: config.get_str("log.log_format").unwrap(),
+            time_fmt: config.get_string("log.time_format").unwrap(),
+            date_fmt: config.get_string("log.date_format").unwrap(),
+            log_fmt: config.get_string("log.log_format").unwrap(),
             filter: config
                 .get_array("log.filter")
                 .unwrap_or_default()
@@ -32,7 +32,7 @@ impl<'a> From<&'a Config> for LoggerConfig {
                 .map(|e| e.to_string())
                 .collect(),
             level: config
-                .get_str("log.level")
+                .get_string("log.level")
                 .map(|l| Level::from_str(&l).unwrap_or(Level::Info))
                 .unwrap_or(Level::Info),
         }


### PR DESCRIPTION
The previous deps on Config crates have caused future-incompatible warnings